### PR TITLE
New features and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ bin
 *.csv
 
 script/dist
+logs/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 jdk:
@@ -7,8 +9,18 @@ cache:
   directories:
     - $HOME/.m2
 
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+
 before_install:
   - "cp .travis.settings.xml $HOME/.m2/settings.xml"
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
+  - google-chrome-stable --remote-debugging-port=9222 http://localhost &
+
+addons:
+  firefox: latest
 
 install:
   - mvn clean install -Dmaven.javadoc.skip=true -B -V

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# selenium-pom-example
+# selenium-pom-framework
 
 [![Build Status](https://travis-ci.com/digital-delivery-academy/selenium-pom-framework.svg?branch=master)](https://travis-ci.com/digital-delivery-academy/selenium-pom-framework)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/122f56e1b6284b319b8c23a58ab2c664)](https://www.codacy.com/gh/digital-delivery-academy/selenium-pom-example?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=digital-delivery-academy/selenium-pom-example&amp;utm_campaign=Badge_Grade)

--- a/config-fs.json
+++ b/config-fs.json
@@ -1,5 +1,12 @@
 {
   "browser": "chrome",
   "baseUrl": "https://www.yahoo.com",
-  "timeout": "30"
+  "timeout": "30",
+  "headless": true,
+  "testConfig": {
+    "sample": "sample text"
+  },
+  "gridConfig": {
+    "url": "http://localhost:4444/wd/hub"
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,9 @@
         <maven.compiler.source>12</maven.compiler.source>
         <maven.compiler.target>12</maven.compiler.target>
         <maven.surefire.version>2.22.2</maven.surefire.version>
+        <maven.failsafe.version>2.22.2</maven.failsafe.version>
         <junit.jupiter.version>5.5.2</junit.jupiter.version>
+        <jetty.version>9.4.26.v20200117</jetty.version>
         <selenium.version>3.141.59</selenium.version>
         <webdriver.manager.version>3.7.1</webdriver.manager.version>
         <slf4j.version>1.6.4</slf4j.version>
@@ -125,6 +127,18 @@
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -136,6 +150,22 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.version}</version>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven.failsafe.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/src/main/java/uk/co/evoco/tests/BaseAbstractTest.java
+++ b/src/main/java/uk/co/evoco/tests/BaseAbstractTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
 import uk.co.evoco.webdriver.WebDriverBuilder;
-import uk.co.evoco.webdriver.configuration.ConfigurationLoader;
-import uk.co.evoco.webdriver.configuration.WebDriverConfig;
+import uk.co.evoco.webdriver.configuration.TestConfigManager;
 import uk.co.evoco.webdriver.results.ResultsManager;
 
 import java.io.IOException;
@@ -17,7 +16,6 @@ import java.io.IOException;
  */
 public abstract class BaseAbstractTest {
     protected EventFiringWebDriver webDriver;
-    protected static WebDriverConfig webDriverConfig;
     protected static ResultsManager resultsManager;
 
     /**
@@ -27,10 +25,7 @@ public abstract class BaseAbstractTest {
      * @throws IOException
      */
     @BeforeAll
-    public static void beforeAll() throws IOException {
-        webDriverConfig = new ConfigurationLoader()
-                .decideWhichConfigurationToUse()
-                .build();
+    public static void beforeAll() {
         resultsManager = new ResultsManager();
         resultsManager.createScreenshotDirectory();
     }
@@ -41,12 +36,11 @@ public abstract class BaseAbstractTest {
      * This ensures we always have a fresh browser window and a guaranteed starting point
      */
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws IOException {
         this.webDriver = new WebDriverBuilder()
-                .setConfiguration(webDriverConfig)
                 .setResultsDirectory(this.resultsManager.getScreenshotDirectory())
                 .build();
-        this.webDriver.get(webDriverConfig.getBaseUrl());
+        this.webDriver.get(TestConfigManager.getInstance().getWebDriverConfig().getBaseUrl());
         this.webDriver.manage().window().maximize();
     }
 

--- a/src/main/java/uk/co/evoco/webdriver/WebDriverBuilder.java
+++ b/src/main/java/uk/co/evoco/webdriver/WebDriverBuilder.java
@@ -1,16 +1,11 @@
 package uk.co.evoco.webdriver;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.edge.EdgeDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.ie.InternetExplorerDriver;
-import org.openqa.selenium.safari.SafariDriver;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
-import uk.co.evoco.webdriver.configuration.WebDriverConfig;
+import uk.co.evoco.webdriver.configuration.TestConfigManager;
+import uk.co.evoco.webdriver.configuration.driver.*;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * This class uses the Builder Pattern to construct its options.  Calling .build() will
@@ -18,21 +13,14 @@ import java.io.File;
  * supplied to the caller
  */
 public class WebDriverBuilder {
-
-    private WebDriverConfig webDriverConfig;
+    
     private File screenshotDirectory;
-
+    
     /**
-     * Allows caller to provide a WebDriverConfig object.  Returns reference to the class instance of WebDriverBuilder
-     * to maintain the builder pattern.
-     * @param webDriverConfig
-     * @return WebDriverBuilder
+     * 
+     * @param screenshotDirectory
+     * @return
      */
-    public WebDriverBuilder setConfiguration(WebDriverConfig webDriverConfig) {
-        this.webDriverConfig = webDriverConfig;
-        return this;
-    }
-
     public WebDriverBuilder setResultsDirectory(File screenshotDirectory) {
         this.screenshotDirectory = screenshotDirectory;
         return this;
@@ -43,39 +31,20 @@ public class WebDriverBuilder {
      * construct an EventFiringWebDriver with the correct configuration for the browser type
      * @return EventFiringWebDriver
      */
-    public EventFiringWebDriver build() {
-        WebDriver webDriver;
-
-        switch(this.webDriverConfig.getBrowserType()) {
+    public EventFiringWebDriver build() throws IOException {
+        switch(TestConfigManager.getInstance().getWebDriverConfig().getBrowserType()) {
             case CHROME:
-                WebDriverManager.chromedriver().setup();
-                webDriver = new ChromeDriver();
-                break;
+                return new ConfiguredChromeDriver(TestConfigManager.getInstance().getWebDriverConfig()).getDriver(this.screenshotDirectory);
             case FIREFOX:
-                WebDriverManager.firefoxdriver().setup();
-                webDriver = new FirefoxDriver();
-                break;
+                return new ConfiguredFirefoxDriver(TestConfigManager.getInstance().getWebDriverConfig()).getDriver(this.screenshotDirectory);
             case IE:
-                WebDriverManager.iedriver().setup();
-                webDriver = new InternetExplorerDriver();
-                break;
+                return new ConfiguredInternetExplorerDriver(TestConfigManager.getInstance().getWebDriverConfig()).getDriver(this.screenshotDirectory);
             case EDGE:
-                WebDriverManager.edgedriver().setup();
-                webDriver = new EdgeDriver();
-                break;
+                return new ConfiguredEdgeDriver(TestConfigManager.getInstance().getWebDriverConfig()).getDriver(this.screenshotDirectory);
             case SAFARI:
-                webDriver = new SafariDriver();
-                break;
+                return new ConfiguredSafariDriver(TestConfigManager.getInstance().getWebDriverConfig()).getDriver(this.screenshotDirectory);
             default:
                 throw new RuntimeException("WebDriverBuilder has no valid target browser set in WebDriverConfig");
         }
-
-        EventFiringWebDriver eventFiringWebDriver = new EventFiringWebDriver(webDriver);
-        WebDriverListener eventListener = new WebDriverListener();
-        eventListener.setWebdriverWaitTimeout(this.webDriverConfig.getWebDriverWaitTimeout());
-        eventListener.setScreenshotDirectory(this.screenshotDirectory);
-        eventFiringWebDriver.register(eventListener);
-
-        return eventFiringWebDriver;
     }
 }

--- a/src/main/java/uk/co/evoco/webdriver/WebDriverListener.java
+++ b/src/main/java/uk/co/evoco/webdriver/WebDriverListener.java
@@ -30,10 +30,18 @@ public class WebDriverListener implements WebDriverEventListener {
     private static final Logger logger = LoggerFactory.getLogger(WebDriverListener.class);
     private File screenshotDirectory;
 
+    /**
+     * Sets the wait for all of the ExpectedConditions calls that we make here
+     * @param webDriverWaitTimeout
+     */
     public void setWebdriverWaitTimeout(long webDriverWaitTimeout) {
         this.WEBDRIVER_WAIT_TIMEOUT = webDriverWaitTimeout;
     }
 
+    /**
+     * Sets the screenshot target directory that will be used for screenshots generated inside onException()
+     * @param screenshotDirectory
+     */
     public void setScreenshotDirectory(File screenshotDirectory) {
         this.screenshotDirectory = screenshotDirectory;
     }

--- a/src/main/java/uk/co/evoco/webdriver/configuration/ConfigurationLoader.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/ConfigurationLoader.java
@@ -38,7 +38,11 @@ public class ConfigurationLoader {
      * @return WebDriverConfig
      * @throws IOException
      */
-    public WebDriverConfig build() throws IOException {
-        return JsonUtils.fromFile(FileLoaderUtils.loadFromClasspathOrFileSystem(targetConfigurationFile), WebDriverConfig.class);
+    public WebDriverConfig build() {
+        try {
+            return JsonUtils.fromFile(FileLoaderUtils.loadFromClasspathOrFileSystem(targetConfigurationFile), WebDriverConfig.class);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to load configuration from " + targetConfigurationFile);
+        }
     }
 }

--- a/src/main/java/uk/co/evoco/webdriver/configuration/GridConfig.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/GridConfig.java
@@ -1,0 +1,19 @@
+package uk.co.evoco.webdriver.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class GridConfig {
+    private URL gridUrl;
+
+    public URL getGridUrl() {
+        return gridUrl;
+    }
+
+    @JsonProperty("url")
+    public void setGridUrl(String gridUrl) throws MalformedURLException {
+        this.gridUrl = new URL(gridUrl);
+    }
+}

--- a/src/main/java/uk/co/evoco/webdriver/configuration/RunType.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/RunType.java
@@ -1,0 +1,6 @@
+package uk.co.evoco.webdriver.configuration;
+
+public enum RunType {
+    LOCAL,
+    GRID
+}

--- a/src/main/java/uk/co/evoco/webdriver/configuration/TestConfigManager.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/TestConfigManager.java
@@ -1,0 +1,24 @@
+package uk.co.evoco.webdriver.configuration;
+
+public class TestConfigManager {
+
+    private static TestConfigManager testConfigManager;
+    private WebDriverConfig webDriverConfig;
+
+    private TestConfigManager() {
+        this.webDriverConfig = new ConfigurationLoader()
+                .decideWhichConfigurationToUse()
+                .build();
+    }
+
+    public static TestConfigManager getInstance() {
+        if(null == testConfigManager) {
+            testConfigManager = new TestConfigManager();
+        }
+        return testConfigManager;
+    }
+
+    public WebDriverConfig getWebDriverConfig() {
+        return webDriverConfig;
+    }
+}

--- a/src/main/java/uk/co/evoco/webdriver/configuration/WebDriverConfig.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/WebDriverConfig.java
@@ -1,9 +1,11 @@
 package uk.co.evoco.webdriver.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 
 /**
  * A simple representation object for the "./src/test/resources/config.json" file
@@ -13,6 +15,11 @@ public class WebDriverConfig {
     private BrowserType browserType;
     private URL baseUrl;
     private long webDriverWaitTimeout;
+    private boolean isHeadless;
+    private JsonNode testConfig;
+    private GridConfig gridConfig;
+    private RunType runType;
+    private List<String> exceptionsToHandleOnTolerantActions;
 
     public BrowserType getBrowserType() {
         return browserType;
@@ -52,5 +59,50 @@ public class WebDriverConfig {
     @JsonProperty("timeout")
     public void setWebDriverWaitTimeout(String webDriverWaitTimeout) {
         this.webDriverWaitTimeout = Long.parseLong(webDriverWaitTimeout);
+    }
+
+    public String getTestConfigItem(String item) {
+        return this.testConfig.get(item).textValue();
+    }
+
+    @JsonProperty("testConfig")
+    public void setTestConfig(JsonNode testConfig) {
+        this.testConfig = testConfig;
+    }
+
+    public boolean isHeadless() {
+        return isHeadless;
+    }
+
+    @JsonProperty("headless")
+    public void setHeadless(boolean headless) {
+        isHeadless = headless;
+    }
+
+    public GridConfig getGridConfig() {
+        return gridConfig;
+    }
+
+    @JsonProperty("gridConfig")
+    public void setGridConfig(GridConfig gridConfig) {
+        this.gridConfig = gridConfig;
+    }
+
+    public RunType getRunType() {
+        return runType;
+    }
+
+    @JsonProperty("runType")
+    public void setRunType(String runType) {
+        this.runType = RunType.valueOf(runType.toUpperCase());
+    }
+
+    public List<String> getExceptionsToHandleOnTolerantActions() {
+        return exceptionsToHandleOnTolerantActions;
+    }
+
+    @JsonProperty("exceptionsToHandleOnTolerantActions")
+    public void setExceptionsToHandleOnTolerantActions(List<String> exceptionsToHandleOnTolerantActions) {
+        this.exceptionsToHandleOnTolerantActions = exceptionsToHandleOnTolerantActions;
     }
 }

--- a/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredChromeDriver.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredChromeDriver.java
@@ -1,0 +1,58 @@
+package uk.co.evoco.webdriver.configuration.driver;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
+import uk.co.evoco.webdriver.configuration.WebDriverConfig;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ConfiguredChromeDriver implements ConfiguredDriver {
+
+    private WebDriverConfig webDriverConfig;
+
+    public ConfiguredChromeDriver(WebDriverConfig webDriverConfig) {
+        this.webDriverConfig = webDriverConfig;
+    }
+
+    public WebDriver getRemoteDriver() {
+        return new RemoteWebDriver(this.webDriverConfig.getGridConfig().getGridUrl(), this.getOptions());
+    }
+
+    public WebDriver getLocalDriver() throws IOException {
+        createLogDirectory();
+        System.setProperty("webdriver.chrome.logfile", "logs/chrome-driver.log");
+        WebDriverManager.chromedriver().setup();
+        return new ChromeDriver(this.getOptions());
+    }
+
+    private ChromeOptions getOptions() {
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.setHeadless(this.webDriverConfig.isHeadless());
+        return chromeOptions;
+    }
+
+    @Override
+    public EventFiringWebDriver getDriver(File screenshotPath) throws IOException {
+        WebDriver webDriver;
+        switch(this.webDriverConfig.getRunType()) {
+            case LOCAL:
+                webDriver = getLocalDriver();
+                break;
+            case GRID:
+                webDriver = getRemoteDriver();
+                break;
+            default:
+                throw new RuntimeException("Must set runType to either LOCAL or GRID in configuration file");
+        }
+        return configureEventFiringWebDriver(
+                webDriver,
+                this.webDriverConfig.getWebDriverWaitTimeout(),
+                screenshotPath);
+    }
+}

--- a/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredDriver.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredDriver.java
@@ -1,0 +1,28 @@
+package uk.co.evoco.webdriver.configuration.driver;
+
+import org.apache.commons.io.FileUtils;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
+import uk.co.evoco.webdriver.WebDriverListener;
+
+import java.io.File;
+import java.io.IOException;
+
+public interface ConfiguredDriver {
+
+    EventFiringWebDriver getDriver(File screenshotPath) throws IOException;
+
+    default EventFiringWebDriver configureEventFiringWebDriver(WebDriver webDriver, long timeout, File screenshotDirectory) {
+        EventFiringWebDriver eventFiringWebDriver = new EventFiringWebDriver(webDriver);
+        WebDriverListener eventListener = new WebDriverListener();
+        eventListener.setWebdriverWaitTimeout(timeout);
+        eventListener.setScreenshotDirectory(screenshotDirectory);
+        eventFiringWebDriver.register(eventListener);
+
+        return eventFiringWebDriver;
+    }
+
+    default void createLogDirectory() throws IOException {
+        FileUtils.forceMkdir(new File("./logs"));
+    }
+}

--- a/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredEdgeDriver.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredEdgeDriver.java
@@ -1,0 +1,52 @@
+package uk.co.evoco.webdriver.configuration.driver;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.edge.EdgeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
+import uk.co.evoco.webdriver.configuration.WebDriverConfig;
+
+import java.io.File;
+
+public class ConfiguredEdgeDriver implements ConfiguredDriver {
+
+    private WebDriverConfig webDriverConfig;
+    private WebDriver webDriver;
+
+    public ConfiguredEdgeDriver(WebDriverConfig webDriverConfig) {
+        this.webDriverConfig = webDriverConfig;
+    }
+
+    public void getRemoteDriver(EdgeOptions edgeOptions) {
+        this.webDriver =  new RemoteWebDriver(this.webDriverConfig.getGridConfig().getGridUrl(), edgeOptions);
+    }
+
+    public void getLocalDriver(EdgeOptions edgeOptions) {
+        WebDriverManager.iedriver().setup();
+        this.webDriver = new EdgeDriver(edgeOptions);
+    }
+
+    public EdgeOptions getOptions() {
+        return new EdgeOptions();
+    }
+
+    @Override
+    public EventFiringWebDriver getDriver(File screenshotPath) {
+        switch(this.webDriverConfig.getRunType()) {
+            case LOCAL:
+                getLocalDriver(this.getOptions());
+                break;
+            case GRID:
+                getRemoteDriver(this.getOptions());
+                break;
+            default:
+                throw new RuntimeException("Must set runType to either LOCAL or GRID in configuration file");
+        }
+        return configureEventFiringWebDriver(
+                this.webDriver,
+                this.webDriverConfig.getWebDriverWaitTimeout(),
+                screenshotPath);
+    }
+}

--- a/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredFirefoxDriver.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredFirefoxDriver.java
@@ -1,0 +1,57 @@
+package uk.co.evoco.webdriver.configuration.driver;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
+import uk.co.evoco.webdriver.configuration.WebDriverConfig;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ConfiguredFirefoxDriver implements ConfiguredDriver {
+
+    private WebDriverConfig webDriverConfig;
+    private WebDriver webDriver;
+
+    public ConfiguredFirefoxDriver(WebDriverConfig webDriverConfig) {
+        this.webDriverConfig = webDriverConfig;
+    }
+
+    public void getRemoteDriver(FirefoxOptions firefoxOptions) {
+        this.webDriver =  new RemoteWebDriver(this.webDriverConfig.getGridConfig().getGridUrl(), firefoxOptions);
+    }
+
+    public void getLocalDriver(FirefoxOptions firefoxOptions) throws IOException {
+        createLogDirectory();
+        System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE,"logs/firefox-driver.logs");
+        WebDriverManager.firefoxdriver().setup();
+        this.webDriver = new FirefoxDriver(firefoxOptions);
+    }
+
+    public FirefoxOptions getOptions() {
+        FirefoxOptions firefoxOptions = new FirefoxOptions();
+        firefoxOptions.setHeadless(this.webDriverConfig.isHeadless());
+        return firefoxOptions;
+    }
+
+    @Override
+    public EventFiringWebDriver getDriver(File screenshotPath) throws IOException {
+        switch(this.webDriverConfig.getRunType()) {
+            case LOCAL:
+                getLocalDriver(this.getOptions());
+                break;
+            case GRID:
+                getRemoteDriver(this.getOptions());
+                break;
+            default:
+                throw new RuntimeException("Must set runType to either LOCAL or GRID in configuration file");
+        }
+        return configureEventFiringWebDriver(
+                this.webDriver,
+                this.webDriverConfig.getWebDriverWaitTimeout(),
+                screenshotPath);
+    }
+}

--- a/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredInternetExplorerDriver.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredInternetExplorerDriver.java
@@ -1,0 +1,52 @@
+package uk.co.evoco.webdriver.configuration.driver;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.ie.InternetExplorerOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
+import uk.co.evoco.webdriver.configuration.WebDriverConfig;
+
+import java.io.File;
+
+public class ConfiguredInternetExplorerDriver implements ConfiguredDriver {
+
+    private WebDriverConfig webDriverConfig;
+    private WebDriver webDriver;
+
+    public ConfiguredInternetExplorerDriver(WebDriverConfig webDriverConfig) {
+        this.webDriverConfig = webDriverConfig;
+    }
+
+    public void getRemoteDriver(InternetExplorerOptions ieOptions) {
+        this.webDriver =  new RemoteWebDriver(this.webDriverConfig.getGridConfig().getGridUrl(), ieOptions);
+    }
+
+    public void getLocalDriver(InternetExplorerOptions ieOptions) {
+        WebDriverManager.iedriver().setup();
+        this.webDriver = new InternetExplorerDriver(ieOptions);
+    }
+
+    public InternetExplorerOptions getOptions() {
+        return new InternetExplorerOptions();
+    }
+
+    @Override
+    public EventFiringWebDriver getDriver(File screenshotPath) {
+        switch(this.webDriverConfig.getRunType()) {
+            case LOCAL:
+                getLocalDriver(this.getOptions());
+                break;
+            case GRID:
+                getRemoteDriver(this.getOptions());
+                break;
+            default:
+                throw new RuntimeException("Must set runType to either LOCAL or GRID in configuration file");
+        }
+        return configureEventFiringWebDriver(
+                this.webDriver,
+                this.webDriverConfig.getWebDriverWaitTimeout(),
+                screenshotPath);
+    }
+}

--- a/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredSafariDriver.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredSafariDriver.java
@@ -1,0 +1,50 @@
+package uk.co.evoco.webdriver.configuration.driver;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.safari.SafariDriver;
+import org.openqa.selenium.safari.SafariOptions;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
+import uk.co.evoco.webdriver.configuration.WebDriverConfig;
+
+import java.io.File;
+
+public class ConfiguredSafariDriver implements ConfiguredDriver {
+
+    private WebDriverConfig webDriverConfig;
+    private WebDriver webDriver;
+
+    public ConfiguredSafariDriver(WebDriverConfig webDriverConfig) {
+        this.webDriverConfig = webDriverConfig;
+    }
+
+    public void getRemoteDriver(SafariOptions safariOptions) {
+        this.webDriver =  new RemoteWebDriver(this.webDriverConfig.getGridConfig().getGridUrl(), safariOptions);
+    }
+
+    public void getLocalDriver(SafariOptions safariOptions) {
+        this.webDriver = new SafariDriver(safariOptions);
+    }
+
+    public SafariOptions getOptions() {
+        return new SafariOptions();
+    }
+
+    @Override
+    public EventFiringWebDriver getDriver(File screenshotPath) {
+        switch(this.webDriverConfig.getRunType()) {
+            case LOCAL:
+                getLocalDriver(this.getOptions());
+                break;
+            case GRID:
+                getRemoteDriver(this.getOptions());
+                break;
+            default:
+                throw new RuntimeException("Must set runType to either LOCAL or GRID in configuration file");
+        }
+        return configureEventFiringWebDriver(
+                this.webDriver,
+                this.webDriverConfig.getWebDriverWaitTimeout(),
+                screenshotPath);
+    }
+}

--- a/src/main/java/uk/co/evoco/webdriver/utils/ClickUtils.java
+++ b/src/main/java/uk/co/evoco/webdriver/utils/ClickUtils.java
@@ -1,0 +1,56 @@
+package uk.co.evoco.webdriver.utils;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.co.evoco.webdriver.configuration.TestConfigManager;
+
+import java.util.List;
+
+/**
+ * Only for us in the situations outlined for the provided methods.
+ * There's nothing wrong with WebDrivers normal click method, if you don't need this, steer well clear.
+ */
+public final class ClickUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(ClickUtils.class);
+
+    /**
+     * Use this method if you're experiencing exceptions that are UN-FIXABLE in your application
+     * and you find that you're getting intermittent (and unhelpful) exceptions.
+     *
+     * This method takes its configuration from the configuration file (see documentation for how to add exceptions
+     * to the list of exceptions that this method will tolerate).
+     *
+     * It retries only once and waits for 3 seconds.  This may become configurable in the future.
+     *
+     * @param webDriver
+     * @param webElement
+     * @throws InterruptedException because there is a Thread.sleep in this method.
+     */
+    public static void tolerantClick(WebDriver webDriver, WebElement webElement) throws InterruptedException {
+        try {
+            click(webDriver, webElement, TestConfigManager.getInstance().getWebDriverConfig().getWebDriverWaitTimeout());
+        } catch(Exception e) {
+            logger.error("Encountered an issue while trying to click, will check to see if we tolerate this exception. Debug this issue to make your tests more stable. Stacktrace follows.");
+            e.printStackTrace();
+            for(String exceptionToHandle : TestConfigManager.getInstance().getWebDriverConfig().getExceptionsToHandleOnTolerantActions()) {
+                if(e.getClass().getName().contains(exceptionToHandle)) {
+                    logger.error("Exception {} is tolerated, retrying after a 3 second wait", exceptionToHandle);
+                    Thread.sleep(3);
+                    logger.error("Waited 3 seconds after {}, now retrying", exceptionToHandle);
+                    click(webDriver, webElement, TestConfigManager.getInstance().getWebDriverConfig().getWebDriverWaitTimeout());
+                }
+            }
+            // Can't handle the exception with a retry so re-throwing the exception
+            throw e;
+        }
+    }
+
+    private static void click(WebDriver webDriver, WebElement webElement, long timeout) {
+        new WebDriverWait(webDriver, timeout).until(ExpectedConditions.elementToBeClickable(webElement)).click();
+    }
+}

--- a/src/main/java/uk/co/evoco/webdriver/utils/JavaScriptUtils.java
+++ b/src/main/java/uk/co/evoco/webdriver/utils/JavaScriptUtils.java
@@ -3,6 +3,7 @@ package uk.co.evoco.webdriver.utils;
 import org.apache.commons.io.FileUtils;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,6 +27,17 @@ public final class JavaScriptUtils {
     }
 
     /**
+     * Executes a given JavaScript script against a given WebElement
+     * @param webDriver
+     * @param webElement
+     * @param javascript
+     */
+    public static void executeString(WebDriver webDriver, WebElement webElement, String javascript) {
+        JavascriptExecutor javascriptExecutor = (JavascriptExecutor) webDriver;
+        javascriptExecutor.executeScript(javascript, webElement);
+    }
+
+    /**
      * Reads a file from the classpath (./src/test/resources/javascript/myfile.js) and executes it via the JavaScript
      * executor.
      * This can make tests a little more readable as there's no inline JavaScript and horrible escape characters to
@@ -41,5 +53,4 @@ public final class JavaScriptUtils {
                 Charset.forName("UTF-8"));
         javascriptExecutor.executeScript(javascript);
     }
-
 }

--- a/src/main/java/uk/co/evoco/webdriver/utils/RadioButtonUtils.java
+++ b/src/main/java/uk/co/evoco/webdriver/utils/RadioButtonUtils.java
@@ -1,0 +1,26 @@
+package uk.co.evoco.webdriver.utils;
+
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+/**
+ * Utility methods to select radio buttons
+ */
+public final class RadioButtonUtils {
+
+    /**
+     * Given a list of WebElements that locate the labels of the radio buttons,
+     * finds the radio button with the given visible label text and selects it.
+     * @param webElements
+     * @param visibleLabelText
+     */
+    public static void selectByLabel(List<WebElement> webElements, String visibleLabelText) {
+        for (WebElement webElement : webElements) {
+            if (webElement.getText().equals(visibleLabelText)) {
+                webElement.click();
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/uk/co/evoco/webdriver/utils/SelectBoxUtils.java
+++ b/src/main/java/uk/co/evoco/webdriver/utils/SelectBoxUtils.java
@@ -21,11 +21,13 @@ public final class SelectBoxUtils {
     }
 
     /**
-     * Selects an option by the index of the option in the list
+     * Selects an option by the index of the option in the list.
+     * The input is NOT zero based, we're normalising the input internally.
      * @param selectBox
      * @param index
      */
     public static void itemByIndex(WebElement selectBox, int index) {
+        index = index - 1;
         Select select = new Select(selectBox);
         select.selectByIndex(index);
     }

--- a/src/main/java/uk/co/evoco/webdriver/utils/WindowUtils.java
+++ b/src/main/java/uk/co/evoco/webdriver/utils/WindowUtils.java
@@ -1,0 +1,19 @@
+package uk.co.evoco.webdriver.utils;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Handles window utilities (like scrolling etc)
+ */
+public class WindowUtils {
+
+    /**
+     * Scrolls a given element into the Viewport view
+     * @param webDriver
+     * @param webElement
+     */
+    public static void scrollIntoView(WebDriver webDriver, WebElement webElement) {
+        JavaScriptUtils.executeString(webDriver, webElement, "arguments[0].scrollIntoView(true);");
+    }
+}

--- a/src/main/java/uk/co/evoco/webdriver/utils/data/Dates.java
+++ b/src/main/java/uk/co/evoco/webdriver/utils/data/Dates.java
@@ -35,4 +35,14 @@ public class Dates extends MockUnitBase {
         LocalDate date = DateTime.parse(startDate, dateTimeFormatter).minusDays(daysToRemove).toLocalDate();
         return date.toString(dateTimeFormatter);
     }
+
+    /**
+     * Returns the current date for today
+     * @return String
+     */
+    public static String now() {
+        DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(DATE_FORMAT);
+        LocalDate date = DateTime.now().toLocalDate();
+        return date.toString(dateTimeFormatter);
+    }
 }

--- a/src/test/java/uk/co/evoco/webdriver/configuration/GridConfigTests.java
+++ b/src/test/java/uk/co/evoco/webdriver/configuration/GridConfigTests.java
@@ -1,0 +1,27 @@
+package uk.co.evoco.webdriver.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class GridConfigTests {
+
+    @Test
+    public void testSettingBaseUrlWithBadGridUrlGivesGoodException() {
+        GridConfig gridConfig = new GridConfig();
+        assertThrows(MalformedURLException.class, () -> {
+            gridConfig.setGridUrl("bad-url");
+        });
+    }
+
+    @Test
+    public void testSettingBaseUrlWithValidGridUrl() throws MalformedURLException {
+        GridConfig gridConfig = new GridConfig();
+        gridConfig.setGridUrl("http://localhost:4444/wd/hub");
+        assertThat(gridConfig.getGridUrl().toString(), is("http://localhost:4444/wd/hub"));
+    }
+}

--- a/src/test/java/uk/co/evoco/webdriver/configuration/TestConfigManagerTests.java
+++ b/src/test/java/uk/co/evoco/webdriver/configuration/TestConfigManagerTests.java
@@ -1,0 +1,20 @@
+package uk.co.evoco.webdriver.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class TestConfigManagerTests {
+
+    @Test
+    public void testCanAccessTestConfigurationIsCorrectType() {
+        assertThat(TestConfigManager.getInstance().getWebDriverConfig(), instanceOf(WebDriverConfig.class));
+    }
+
+    @Test
+    public void testCanAccessTestConfigurationViaSingleton() {
+        assertThat(TestConfigManager.getInstance().getWebDriverConfig().getBaseUrl(), is("https://www.google.com"));
+    }
+}

--- a/src/test/java/uk/co/evoco/webdriver/configuration/WebDriverConfigTests.java
+++ b/src/test/java/uk/co/evoco/webdriver/configuration/WebDriverConfigTests.java
@@ -19,6 +19,9 @@ public class WebDriverConfigTests {
         assertThat(webDriverConfig.getBaseUrl(), is("https://www.google.com"));
         assertThat(webDriverConfig.getBrowserType(), is(BrowserType.CHROME));
         assertThat(webDriverConfig.getWebDriverWaitTimeout(), is(30L));
+        assertThat(webDriverConfig.getTestConfigItem("sample"), is("sample text"));
+        assertThat(webDriverConfig.getRunType(), is(RunType.LOCAL));
+        assertThat(webDriverConfig.getGridConfig().getGridUrl().toString(), is("http://localhost:4444/wd/hub"));
     }
 
     @Test

--- a/src/test/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredChromeDriverIT.java
+++ b/src/test/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredChromeDriverIT.java
@@ -1,0 +1,24 @@
+package uk.co.evoco.webdriver.configuration.driver;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
+import uk.co.evoco.webdriver.configuration.WebDriverConfig;
+import uk.co.evoco.webdriver.utils.JsonUtils;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ConfiguredChromeDriverIT {
+
+    @Test
+    public void testReturnsLocalWebDriver() throws IOException {
+        WebDriverConfig webDriverConfig = JsonUtils.fromFile(ClassLoader.getSystemResourceAsStream("fixtures/sample-config.json"), WebDriverConfig.class);
+        ConfiguredChromeDriver configuredChromeDriver = new ConfiguredChromeDriver(webDriverConfig);
+        WebDriver webDriver = configuredChromeDriver.getDriver(FileUtils.getTempDirectory());
+        assertThat(webDriver, instanceOf(EventFiringWebDriver.class));
+    }
+}

--- a/src/test/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredEdgeDriverIT.java
+++ b/src/test/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredEdgeDriverIT.java
@@ -1,0 +1,33 @@
+package uk.co.evoco.webdriver.configuration.driver;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.co.evoco.webdriver.configuration.WebDriverConfig;
+import uk.co.evoco.webdriver.utils.JsonUtils;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ConfiguredEdgeDriverIT {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConfiguredEdgeDriverIT.class);
+
+    @Test
+    public void testReturnsLocalWebDriver() throws IOException {
+        if(System.getProperty("os.name").contains("win")) {
+            WebDriverConfig webDriverConfig = JsonUtils.fromFile(ClassLoader.getSystemResourceAsStream("fixtures/sample-config.json"), WebDriverConfig.class);
+            ConfiguredEdgeDriver configuredEdgeDriver = new ConfiguredEdgeDriver(webDriverConfig);
+            WebDriver webDriver = configuredEdgeDriver.getDriver(FileUtils.getTempDirectory());
+            assertThat(webDriver, instanceOf(EventFiringWebDriver.class));
+            webDriver.quit();
+        } else {
+            logger.warn("ConfiguredEdgeDriverTests.testReturnsLocalWebDriver is dependant on being on Windows, you're not on Windows so it didn't run.");
+        }
+    }
+}

--- a/src/test/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredFirefoxDriverIT.java
+++ b/src/test/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredFirefoxDriverIT.java
@@ -1,0 +1,24 @@
+package uk.co.evoco.webdriver.configuration.driver;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
+import uk.co.evoco.webdriver.configuration.WebDriverConfig;
+import uk.co.evoco.webdriver.utils.JsonUtils;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ConfiguredFirefoxDriverIT {
+
+    @Test
+    public void testReturnsLocalWebDriver() throws IOException {
+        WebDriverConfig webDriverConfig = JsonUtils.fromFile(ClassLoader.getSystemResourceAsStream("fixtures/sample-config.json"), WebDriverConfig.class);
+        ConfiguredFirefoxDriver configuredFirefoxDriver = new ConfiguredFirefoxDriver(webDriverConfig);
+        WebDriver webDriver = configuredFirefoxDriver.getDriver(FileUtils.getTempDirectory());
+        assertThat(webDriver, instanceOf(EventFiringWebDriver.class));
+    }
+}

--- a/src/test/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredInternetExplorerDriverIT.java
+++ b/src/test/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredInternetExplorerDriverIT.java
@@ -1,0 +1,33 @@
+package uk.co.evoco.webdriver.configuration.driver;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.co.evoco.webdriver.configuration.WebDriverConfig;
+import uk.co.evoco.webdriver.utils.JsonUtils;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ConfiguredInternetExplorerDriverIT {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConfiguredInternetExplorerDriverIT.class);
+
+    @Test
+    public void testReturnsLocalWebDriver() throws IOException {
+        if(System.getProperty("os.name").contains("win")) {
+            WebDriverConfig webDriverConfig = JsonUtils.fromFile(ClassLoader.getSystemResourceAsStream("fixtures/sample-config.json"), WebDriverConfig.class);
+            ConfiguredInternetExplorerDriver configuredIeDriver = new ConfiguredInternetExplorerDriver(webDriverConfig);
+            WebDriver webDriver = configuredIeDriver.getDriver(FileUtils.getTempDirectory());
+            assertThat(webDriver, instanceOf(EventFiringWebDriver.class));
+            webDriver.quit();
+        } else {
+            logger.warn("ConfiguredInternetExplorerTests.testReturnsLocalWebDriver is dependant on being on Windows, you're not on Windows so it didn't run.");
+        }
+    }
+}

--- a/src/test/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredSafariDriverIT.java
+++ b/src/test/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredSafariDriverIT.java
@@ -1,0 +1,33 @@
+package uk.co.evoco.webdriver.configuration.driver;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.co.evoco.webdriver.configuration.WebDriverConfig;
+import uk.co.evoco.webdriver.utils.JsonUtils;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ConfiguredSafariDriverIT {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConfiguredSafariDriverIT.class);
+
+    @Test
+    public void testReturnsLocalWebDriver() throws IOException {
+        if(System.getProperty("os.name").contains("mac")) {
+            WebDriverConfig webDriverConfig = JsonUtils.fromFile(ClassLoader.getSystemResourceAsStream("fixtures/sample-config.json"), WebDriverConfig.class);
+            ConfiguredSafariDriver configuredSafariDriver = new ConfiguredSafariDriver(webDriverConfig);
+            WebDriver webDriver = configuredSafariDriver.getDriver(FileUtils.getTempDirectory());
+            assertThat(webDriver, instanceOf(EventFiringWebDriver.class));
+            webDriver.quit();
+        } else {
+            logger.warn("ConfiguredSafariDriverTests.testReturnsLocalWebDriver is dependant on being on Mac, you're not on Mac so it didn't run.");
+        }
+    }
+}

--- a/src/test/java/uk/co/evoco/webdriver/utils/EmbeddedJetty.java
+++ b/src/test/java/uk/co/evoco/webdriver/utils/EmbeddedJetty.java
@@ -1,0 +1,31 @@
+package uk.co.evoco.webdriver.utils;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.eclipse.jetty.util.resource.Resource;
+
+public class EmbeddedJetty {
+
+    private Server jettyServer;
+
+    public EmbeddedJetty() {
+        jettyServer = new Server(4442);
+    }
+
+    public void start() throws Exception {
+        ResourceHandler resHandler = new ResourceHandler();
+        resHandler.setBaseResource(Resource.newClassPathResource("/www"));
+        jettyServer.setHandler(resHandler);
+        jettyServer.start();
+        Thread.sleep(10000);
+    }
+
+    public void stop() throws Exception {
+        jettyServer.stop();
+    }
+
+    public int getPort() {
+//        return ((ServerConnector) this.jettyServer.getConnectors()[0]).getLocalPort();
+        return 4442;
+    }
+}

--- a/src/test/java/uk/co/evoco/webdriver/utils/WebDriverUtilsIT.java
+++ b/src/test/java/uk/co/evoco/webdriver/utils/WebDriverUtilsIT.java
@@ -1,0 +1,80 @@
+package uk.co.evoco.webdriver.utils;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import uk.co.evoco.tests.BaseAbstractTest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class WebDriverUtilsIT extends BaseAbstractTest {
+
+    private static String baseUrl;
+    private static EmbeddedJetty embeddedJetty;
+
+    @BeforeAll
+    public static void webDriverSetup() throws Exception {
+        embeddedJetty = new EmbeddedJetty();
+        embeddedJetty.start();
+        baseUrl = "http://localhost:" + embeddedJetty.getPort() + "/index.html";
+    }
+
+    @AfterAll
+    public static void webDriverTearDown() throws Exception {
+        embeddedJetty.stop();
+    }
+
+    @BeforeEach
+    public void setUpWebApp() {
+        webDriver.get(baseUrl);
+    }
+
+    @Test
+    public void testServerIsAvailable() {
+        assertThat(webDriver.getCurrentUrl(), is(baseUrl));
+    }
+
+    @Test
+    public void testFindByUtilsMultipleMatchesToLocatorClickOnDisplayed() {
+        FindByUtils.multipleLocatorMatchGetDisplayed(webDriver, By.className("findbyutils-button")).click();
+        assertThat(webDriver.getCurrentUrl(), is("http://localhost:4442/hello-passed.html"));
+    }
+
+    @Test
+    public void testRadioButtonUtilsSelectByLabel() {
+        RadioButtonUtils.selectByLabel(webDriver.findElements(
+                By.xpath("//div[@data-test-id='radio-button-group']/label")), "Value 2");
+        assertThat(webDriver.findElement(By.id("radio-button-value2")).isSelected(), is(true));
+        assertThat(webDriver.findElement(By.id("radio-button-value1")).isSelected(), is(false));
+        assertThat(webDriver.findElement(By.id("radio-button-value3")).isSelected(), is(false));
+    }
+
+    @Test
+    public void testSelectBoxUtilsWithItemByHtmlValueAttribute() {
+        SelectBoxUtils.itemByHtmlValueAttribute(webDriver.findElement(By.id("select-box")), "option2");
+        assertThat(webDriver.findElement(By.id("select-box-option2")).isSelected(), is(true));
+        assertThat(webDriver.findElement(By.id("select-box-option1")).isSelected(), is(false));
+        assertThat(webDriver.findElement(By.id("select-box-option3")).isSelected(), is(false));
+    }
+
+    @Test
+    public void testSelectBoxUtilsWithItemByIndex() {
+        SelectBoxUtils.itemByIndex(webDriver.findElement(By.id("select-box")), 3);
+        assertThat(webDriver.findElement(By.id("select-box-option3")).isSelected(), is(true));
+        assertThat(webDriver.findElement(By.id("select-box-option2")).isSelected(), is(false));
+        assertThat(webDriver.findElement(By.id("select-box-option1")).isSelected(), is(false));
+    }
+
+    @Test
+    public void testWindowUtilsScrollIntoView() {
+        WebElement elementOutOfView = webDriver.findElement(By.id("out-of-viewport-link"));
+        WindowUtils.scrollIntoView(webDriver, elementOutOfView);
+        elementOutOfView.click();
+        assertThat(webDriver.getCurrentUrl(), is("http://localhost:4442/hello-passed.html"));
+    }
+
+}

--- a/src/test/resources/config.json
+++ b/src/test/resources/config.json
@@ -1,5 +1,18 @@
 {
   "browser": "chrome",
   "baseUrl": "https://www.google.com",
-  "timeout": "30"
+  "timeout": "30",
+  "headless": true,
+  "runType": "LOCAL",
+  "testConfig": {
+    "sample": "sample text"
+  },
+  "gridConfig": {
+    "url": "http://localhost:4444/wd/hub"
+  },
+  "exceptionsToHandleOnTolerantActions": [
+    "StaleElementReferenceException",
+    "ElementClickInterceptedException",
+    "ElementNotInteractableException"
+  ]
 }

--- a/src/test/resources/fixtures/sample-config-with-bad-base-url.json
+++ b/src/test/resources/fixtures/sample-config-with-bad-base-url.json
@@ -1,5 +1,13 @@
 {
   "browser": "chrome",
   "baseUrl": "bad-base-url",
-  "timeout": "30"
+  "timeout": "30",
+  "headless": true,
+  "runType": "LOCAL",
+  "testConfig": {
+    "sample": "sample text"
+  },
+  "gridConfig": {
+    "url": "http://localhost:4444/wd/hub"
+  }
 }

--- a/src/test/resources/fixtures/sample-config-with-bad-grid-url.json
+++ b/src/test/resources/fixtures/sample-config-with-bad-grid-url.json
@@ -8,6 +8,6 @@
     "sample": "sample text"
   },
   "gridConfig": {
-    "url": "http://localhost:4444/wd/hub"
+    "url": "bad-base-url"
   }
 }

--- a/src/test/resources/fixtures/sample-grid-config.json
+++ b/src/test/resources/fixtures/sample-grid-config.json
@@ -3,7 +3,7 @@
   "baseUrl": "https://www.google.com",
   "timeout": "30",
   "headless": true,
-  "runType": "LOCAL",
+  "runType": "GRID",
   "testConfig": {
     "sample": "sample text"
   },

--- a/src/test/resources/www/hello-failed.html
+++ b/src/test/resources/www/hello-failed.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <title>selenium-pom-framework - test page for integration tests</title>
+</head>
+<body>
+    <h1>Hello. Everything failed :(</h1>
+</body>
+</html>

--- a/src/test/resources/www/hello-passed.html
+++ b/src/test/resources/www/hello-passed.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <title>selenium-pom-framework - test page for integration tests</title>
+</head>
+<body>
+<h1>Hello. Everything passed :)</h1>
+</body>
+</html>

--- a/src/test/resources/www/index.html
+++ b/src/test/resources/www/index.html
@@ -1,0 +1,37 @@
+<html>
+    <head>
+        <title>selenium-pom-framework - test page for integration tests</title>
+    </head>
+    <body>
+        <div id="FindByUtils-elements">
+            <a href="/hello-failed.html" class="findbyutils-button" style="display:none;">Button 1 (hidden)</a>
+            <a href="/hello-passed.html" class="findbyutils-button">Button 2 (displayed)</a>
+        </div>
+        <div id="RadioButtonUtils-elements">
+            <form>
+                <div class="form-group" data-test-id="radio-button-group">
+                    <input id="radio-button-value1" type="radio" value="value1">
+                    <label for="radio-button-value1">Value 1</label>
+                </div>
+                <div class="form-group" data-test-id="radio-button-group">
+                    <input id="radio-button-value2" type="radio" value="value2">
+                    <label for="radio-button-value2">Value 2</label>
+                </div>
+                <div class="form-group" data-test-id="radio-button-group">
+                    <input id="radio-button-value3" type="radio" value="value3">
+                    <label for="radio-button-value3">Value 3</label>
+                </div>
+            </form>
+        </div>
+        <div id="SelectBoxUtils-elements">
+            <select id="select-box">
+                <option id="select-box-option1" value="option1">Option 1</option>
+                <option id="select-box-option2" value="option2">Option 2</option>
+                <option id="select-box-option3" value="option3">Option 3</option>
+            </select>
+        </div>
+        <div id="WindowUtils-elements">
+            <a id="out-of-viewport-link" href="hello-passed.html" stype="margin-top:2000px;">Link out of viewport on page load</a>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
### Features/fixes/changes:

- BaseAbstractTest: amended to as the config is now a singleton
- u.c.e.w.configuration.Configured*: added interface and implementations for each driver to allow us to use the grid configuration that comes from the config file and only to download the binaries if we're local
- ConfigurationLoader: removed some of the options for the builder so we can use it in the TestConfigManager singleton
- TestConfigManger: a singleton to make the configuration available anywhere and to only have one instance of it
- GridConfig: data model to represent the object in the config file
- RunType: enum for local or grid runs
- WebDriverConfig: some additional fields for exception tolerance, grid, run type and generic test config
- ClickUtils: a tolerant click that handles the exceptions passed in the config file and retries once
- RadioButtonUtils: methods to select radio buttons by visible labels
- JavaScriptUtils: added method to handle running javascript on a specific WebElement
- WindowUtils: added scrollIntoView method (which uses new methods in JavaScriptUtils)
- SelectBoxUtils: making itemByIndex work not on 0 based numbers (so that the argument can be presented logically i.e. 1 instead of 0)
- WebDriverBuilder: refactored after the introduction of ConfiguredDrivers and a TestConfigManager
- WebDriverListener: a few fixes for screenshots - found issue #13 here
- Dates: added a method for getting todays date

### Test (see issue #7):

- Added more unit tests
- Added integration tests for browser driver loading locally - these tests are platform dependant (mac or windows) because of the browsers. They depend on the browsers being installed
- Added integration test for the helper utilities
- Added a small sample web app that is embedded with jetty to allow us to have a sample HTML page to test the helper utilities in bad situations, this is still WIP, and is dependant on port 4442 being open.

### Dependencies:
- Added jetty-server and jetty-servlet (probably need to remove jetty-servlet (see issue #14)
- Added surefire plugin to run integration tests - these can now be ran on `mvn verify`