### PR TITLE
Adding static build time reference to bank holidays in case CI system…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ bin
 
 script/dist
 logs/*
+src/main/resources/bank-holidays.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 - google-chrome-stable --remote-debugging-port=9222 http://localhost &
 - chmod ugo+x scripts/publish-javadocs-to-github-pages.sh
+- chmod ugo+x scripts/get-bank-holiday-data-source-and-store-in-resources.sh
 addons:
   firefox: latest
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
   firefox: latest
 install:
 - mvn clean install -Dmaven.javadoc.skip=true -B -V
+- bash scripts/get-bank-holiday-data-source-and-store-in-resources.sh
 after_success:
 - gpg2 --keyring=$TRAVIS_BUILD_DIR/pubring.gpg --no-default-keyring --import deployment/signingkey.asc
 - gpg2 --allow-secret-key-import --keyring=$TRAVIS_BUILD_DIR/secring.gpg --no-default-keyring

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
                 <version>2.5.3</version>
                 <configuration>
                     <localCheckout>true</localCheckout>
-                    <pushChanges>true</pushChanges>
+                    <pushChanges>false</pushChanges>
                     <mavenExecutorId>forked-path</mavenExecutorId>
                     <arguments>-Dgpg.passphrase=${env.GPG_PASSPHRASE} -Dmaven.test.skip=true</arguments>
                     <checkModificationExcludes>

--- a/scripts/get-bank-holiday-data-source-and-store-in-resources.sh
+++ b/scripts/get-bank-holiday-data-source-and-store-in-resources.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+curl https://www.gov.uk/bank-holidays.json --output src/main/resources/bank-holidays.json
+echo "STEVE STEVE STEVE"
+ls src/main/resources

--- a/src/test/java/uk/co/evoco/testdata/DatesTests.java
+++ b/src/test/java/uk/co/evoco/testdata/DatesTests.java
@@ -6,7 +6,10 @@ import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static uk.co.evoco.testdata.Dates.*;
+import static uk.co.evoco.testdata.Dates.futureDateAvoidingWeekends;
+import static uk.co.evoco.testdata.Dates.futureDate;
+import static uk.co.evoco.testdata.Dates.pastDate;
+import static uk.co.evoco.testdata.Dates.futureDataAvoidingWeekendsAndBankHolidays;
 
 public class DatesTests {
 

--- a/src/test/java/uk/co/evoco/testdata/DatesTests.java
+++ b/src/test/java/uk/co/evoco/testdata/DatesTests.java
@@ -1,14 +1,12 @@
 package uk.co.evoco.testdata;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static uk.co.evoco.testdata.Dates.futureDate;
-import static uk.co.evoco.testdata.Dates.pastDate;
-import static uk.co.evoco.testdata.Dates.futureDateAvoidingWeekends;
-import static uk.co.evoco.testdata.Dates.futureDataAvoidingWeekendsAndBankHolidays;
+import static uk.co.evoco.testdata.Dates.*;
 
 public class DatesTests {
 
@@ -31,7 +29,7 @@ public class DatesTests {
     }
 
     @Test
-    public void testCanGetDateInFutureAvoidingWeekendsAndBankHolidays() throws JsonProcessingException {
+    public void testCanGetDateInFutureAvoidingWeekendsAndBankHolidays() throws IOException {
         assertThat(futureDataAvoidingWeekendsAndBankHolidays(
                 Locale.ENGLAND_AND_WALES, "28/08/2017", 2, "dd/MM/yyyy"),
                 is("31/08/2017"));
@@ -39,7 +37,7 @@ public class DatesTests {
 
     @Test
     public void testCanGetDateInFutureAvoidingWeekendsAndBankHolidaysWhenStartDateIsOnFriday()
-            throws JsonProcessingException {
+            throws IOException {
         assertThat(futureDataAvoidingWeekendsAndBankHolidays(
                 Locale.ENGLAND_AND_WALES, "25/08/2017", 2, "dd/MM/yyyy"),
                 is("30/08/2017"));


### PR DESCRIPTION
…s can't reach out to the internet to get them. Fixing issue #33

## Fixes 
Fixing issue #33 

## Description
Adding a way for bank holidays to be packaged at build time in case some users can't access the internet from their CI systems (this is pretty typical in gov or more secure environments)
