### PR TITLE
Fix Bug with TolerantInteraction.propagateIfNotIgnored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: java
 jdk:
-- openjdk12
+- openjdk13
 cache:
   directories:
   - "$HOME/.m2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 addons:
   firefox: latest
 install:
+- java --version
 - mvn clean install -Dmaven.javadoc.skip=true -B -V
 - bash scripts/get-bank-holiday-data-source-and-store-in-resources.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_install:
 addons:
   firefox: latest
 install:
-- java --version
 - mvn clean install -Dmaven.javadoc.skip=true -B -V
 - bash scripts/get-bank-holiday-data-source-and-store-in-resources.sh
 after_success:

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>12</maven.compiler.source>
-        <maven.compiler.target>12</maven.compiler.target>
+        <maven.compiler.source>13</maven.compiler.source>
+        <maven.compiler.target>13</maven.compiler.target>
         <maven.surefire.version>2.22.2</maven.surefire.version>
         <maven.failsafe.version>2.22.2</maven.failsafe.version>
         <junit.jupiter.version>5.5.2</junit.jupiter.version>

--- a/src/main/java/uk/co/evoco/webdriver/utils/TolerantExceptionHandler.java
+++ b/src/main/java/uk/co/evoco/webdriver/utils/TolerantExceptionHandler.java
@@ -28,7 +28,7 @@ public class TolerantExceptionHandler {
      * @return the input exception if is on the tolerant exceptions list
      * @throws Throwable the input exception if it's not on the tolerant exceptions list
      */
-    public Throwable handle(Throwable throwable) throws Throwable {
+    public Throwable propagateIfNotIgnored(Throwable throwable) throws Throwable {
         for (String tolerantExceptionClassName : tolerantExceptions) {
             if (isInstanceOf(tolerantExceptionClassName, throwable)) {
                 logger.info("Exception {} will be ignored", tolerantExceptionClassName);

--- a/src/main/java/uk/co/evoco/webdriver/utils/TolerantExceptionHandler.java
+++ b/src/main/java/uk/co/evoco/webdriver/utils/TolerantExceptionHandler.java
@@ -1,0 +1,48 @@
+package uk.co.evoco.webdriver.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class TolerantExceptionHandler {
+    private List<String> tolerantExceptions;
+    private Logger logger = LoggerFactory.getLogger(TolerantInteraction.class);
+
+    public TolerantExceptionHandler(List<String> tolerantExceptions) {
+        this.tolerantExceptions = tolerantExceptions;
+    }
+
+    public TolerantExceptionHandler(List<String> tolerantExceptions, Logger logger) {
+        this(tolerantExceptions);
+        this.logger = logger;
+    }
+
+    /**
+     * Checks an input exception against a predefined list of tolerant exceptions. It either:
+     * <ol>
+     *     <li>returns the exception (if it's on the tolerant list) or</li>
+     *     <li>throws the exception if it's not on the tolerant list.</li>
+     * </ol>
+     * @param throwable the throwable that needs to be handled
+     * @return the input exception if is on the tolerant exceptions list
+     * @throws Throwable the input exception if it's not on the tolerant exceptions list
+     */
+    public Throwable handle(Throwable throwable) throws Throwable {
+        for (String tolerantExceptionClassName : tolerantExceptions) {
+            if (isInstanceOf(tolerantExceptionClassName, throwable)) {
+                logger.info("Exception {} will be ignored", tolerantExceptionClassName);
+                return throwable;
+            }
+        }
+        throw throwable;
+    }
+
+    private boolean isInstanceOf (String source, Throwable target) {
+        try {
+            return Class.forName(source).isInstance(target);
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/uk/co/evoco/webdriver/utils/TolerantInteraction.java
+++ b/src/main/java/uk/co/evoco/webdriver/utils/TolerantInteraction.java
@@ -55,7 +55,7 @@ public class TolerantInteraction {
                     return webElement;
                 }
             } catch (Throwable e) {
-                lastException = tolerantExceptionHandler.handle(e);
+                lastException = tolerantExceptionHandler.propagateIfNotIgnored(e);
             }
 
             if (end.isBefore(clock.instant())) {
@@ -99,7 +99,7 @@ public class TolerantInteraction {
                     }
                 }
             } catch (Throwable e) {
-                lastException = tolerantExceptionHandler.handle(e);
+                lastException = tolerantExceptionHandler.propagateIfNotIgnored(e);
             }
 
             if (end.isBefore(clock.instant())) {
@@ -144,7 +144,7 @@ public class TolerantInteraction {
                     return webElement;
                 }
             } catch(Throwable e) {
-                lastException = tolerantExceptionHandler.handle(e);
+                lastException = tolerantExceptionHandler.propagateIfNotIgnored(e);
             }
             if(end.isBefore(clock.instant())) {
                 if(null == lastException) {
@@ -186,7 +186,7 @@ public class TolerantInteraction {
                     return interactToGetAttribute(webElement, attribute);
                 }
             } catch (Throwable e) {
-                lastException = tolerantExceptionHandler.handle(e);
+                lastException = tolerantExceptionHandler.propagateIfNotIgnored(e);
             }
             if (end.isBefore(clock.instant())) {
                 if (null == lastException) {
@@ -227,7 +227,7 @@ public class TolerantInteraction {
                     return interactToGetText(webElement);
                 }
             } catch (Throwable e) {
-                lastException = tolerantExceptionHandler.handle(e);
+                lastException = tolerantExceptionHandler.propagateIfNotIgnored(e);
             }
             if (end.isBefore(clock.instant())) {
                 if (null == lastException) {
@@ -269,7 +269,7 @@ public class TolerantInteraction {
                     return webElement;
                 }
             } catch (Throwable e) {
-                lastException = tolerantExceptionHandler.handle(e);
+                lastException = tolerantExceptionHandler.propagateIfNotIgnored(e);
             }
             if (end.isBefore(clock.instant())) {
                 if (null == lastException) {

--- a/src/main/java/uk/co/evoco/webdriver/utils/TolerantInteraction.java
+++ b/src/main/java/uk/co/evoco/webdriver/utils/TolerantInteraction.java
@@ -24,6 +24,9 @@ public class TolerantInteraction {
     private final Sleeper sleeper = Sleeper.SYSTEM_SLEEPER;
     private final Duration intervalDuration = Duration.ofMillis(500);
     private Throwable lastException = null;
+    private TolerantExceptionHandler tolerantExceptionHandler = new TolerantExceptionHandler(
+            TestConfigHelper.get().getTolerantActionExceptions().getExceptionsToHandle(),
+            logger);
 
     /**
      *
@@ -52,7 +55,7 @@ public class TolerantInteraction {
                     return webElement;
                 }
             } catch (Throwable e) {
-                lastException = propagateIfNotIgnored(e);
+                lastException = tolerantExceptionHandler.handle(e);
             }
 
             if (end.isBefore(clock.instant())) {
@@ -96,7 +99,7 @@ public class TolerantInteraction {
                     }
                 }
             } catch (Throwable e) {
-                lastException = propagateIfNotIgnored(e);
+                lastException = tolerantExceptionHandler.handle(e);
             }
 
             if (end.isBefore(clock.instant())) {
@@ -141,7 +144,7 @@ public class TolerantInteraction {
                     return webElement;
                 }
             } catch(Throwable e) {
-                lastException = propagateIfNotIgnored(e);
+                lastException = tolerantExceptionHandler.handle(e);
             }
             if(end.isBefore(clock.instant())) {
                 if(null == lastException) {
@@ -183,7 +186,7 @@ public class TolerantInteraction {
                     return interactToGetAttribute(webElement, attribute);
                 }
             } catch (Throwable e) {
-                lastException = propagateIfNotIgnored(e);
+                lastException = tolerantExceptionHandler.handle(e);
             }
             if (end.isBefore(clock.instant())) {
                 if (null == lastException) {
@@ -224,7 +227,7 @@ public class TolerantInteraction {
                     return interactToGetText(webElement);
                 }
             } catch (Throwable e) {
-                lastException = propagateIfNotIgnored(e);
+                lastException = tolerantExceptionHandler.handle(e);
             }
             if (end.isBefore(clock.instant())) {
                 if (null == lastException) {
@@ -266,7 +269,7 @@ public class TolerantInteraction {
                     return webElement;
                 }
             } catch (Throwable e) {
-                lastException = propagateIfNotIgnored(e);
+                lastException = tolerantExceptionHandler.handle(e);
             }
             if (end.isBefore(clock.instant())) {
                 if (null == lastException) {
@@ -326,17 +329,5 @@ public class TolerantInteraction {
     private void interact(Select selectBox, int index) {
         int normalisedIndex = index - 1;
         selectBox.selectByIndex(normalisedIndex);
-    }
-
-    private Throwable propagateIfNotIgnored(Throwable e) throws Throwable {
-        for (String ignoredException : TestConfigHelper.get()
-                .getTolerantActionExceptions().getExceptionsToHandle()) {
-            if (Class.forName(ignoredException).isInstance(e)) {
-                logger.info("Exception {} will be ignored", ignoredException);
-            } else {
-                return e;
-            }
-        }
-        return e;
     }
 }

--- a/src/test/java/uk/co/evoco/webdriver/utils/TolerantExceptionHandlerTests.java
+++ b/src/test/java/uk/co/evoco/webdriver/utils/TolerantExceptionHandlerTests.java
@@ -13,14 +13,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class TolerantExceptionHandlerTests {
 
     @Test
-    void testThrowsInputExceptionIfNoTolerantExceptionsAreListed() {
+    public void testThrowsInputExceptionIfNoTolerantExceptionsAreListed() {
         TolerantExceptionHandler handler = new TolerantExceptionHandler(new ArrayList<>());
         NumberFormatException inputException = new NumberFormatException();
         assertThrows(NumberFormatException.class, () -> handler.propagateIfNotIgnored(inputException));
     }
 
     @Test
-    void testThrowsInputExceptionIfNotOnListOfTolerantExceptions() {
+    public void testThrowsInputExceptionIfNotOnListOfTolerantExceptions() {
         List<String> tolerantExceptions = new ArrayList<>();
         tolerantExceptions.add(NullPointerException.class.getName());
         tolerantExceptions.add(InvalidArgumentException.class.getName());
@@ -32,7 +32,7 @@ public class TolerantExceptionHandlerTests {
     }
 
     @Test
-    void testReturnsInputExceptionIfOnListOfTolerantExceptions() throws Throwable {
+    public void testReturnsInputExceptionIfOnListOfTolerantExceptions() throws Throwable {
         List<String> tolerantExceptions = new ArrayList<>();
         tolerantExceptions.add(NullPointerException.class.getName());
         tolerantExceptions.add(ArithmeticException.class.getName());
@@ -44,7 +44,7 @@ public class TolerantExceptionHandlerTests {
     }
 
     @Test
-    void testIgnoresInvalidValuesInTolerantExceptionList () throws Throwable {
+    public void testIgnoresInvalidValuesInTolerantExceptionList () throws Throwable {
         List<String> tolerantExceptions = new ArrayList<>();
         tolerantExceptions.add("NonExistentClass");
         tolerantExceptions.add(InvalidArgumentException.class.getName());
@@ -56,7 +56,7 @@ public class TolerantExceptionHandlerTests {
     }
 
     @Test
-    void testIgnoresClassesInTolerantExceptionListThatAreNotThrowable () throws Throwable {
+    public void testIgnoresClassesInTolerantExceptionListThatAreNotThrowable () throws Throwable {
         List<String> tolerantExceptions = new ArrayList<>();
         tolerantExceptions.add("java.lang.String");
         tolerantExceptions.add(InvalidArgumentException.class.getName());

--- a/src/test/java/uk/co/evoco/webdriver/utils/TolerantExceptionHandlerTests.java
+++ b/src/test/java/uk/co/evoco/webdriver/utils/TolerantExceptionHandlerTests.java
@@ -1,11 +1,14 @@
 package uk.co.evoco.webdriver.utils;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.InvalidArgumentException;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 
 public class TolerantExceptionHandlerTests {
 
@@ -13,7 +16,7 @@ public class TolerantExceptionHandlerTests {
     void testThrowsInputExceptionIfNoTolerantExceptionsAreListed() {
         TolerantExceptionHandler handler = new TolerantExceptionHandler(new ArrayList<>());
         NumberFormatException inputException = new NumberFormatException();
-        Assertions.assertThrows(NumberFormatException.class, () -> handler.handle(inputException));
+        assertThrows(NumberFormatException.class, () -> handler.handle(inputException));
     }
 
     @Test
@@ -25,7 +28,7 @@ public class TolerantExceptionHandlerTests {
         TolerantExceptionHandler handler = new TolerantExceptionHandler(tolerantExceptions);
 
         NumberFormatException inputException = new NumberFormatException();
-        Assertions.assertThrows(NumberFormatException.class, () -> handler.handle(inputException));
+        assertThrows(NumberFormatException.class, () -> handler.handle(inputException));
     }
 
     @Test
@@ -37,7 +40,7 @@ public class TolerantExceptionHandlerTests {
         TolerantExceptionHandler handler = new TolerantExceptionHandler(tolerantExceptions);
 
         ArithmeticException inputException = new ArithmeticException();
-        Assertions.assertEquals(inputException, handler.handle(inputException));
+        assertEquals(inputException, handler.handle(inputException));
     }
 
     @Test
@@ -49,7 +52,7 @@ public class TolerantExceptionHandlerTests {
         TolerantExceptionHandler handler = new TolerantExceptionHandler(tolerantExceptions);
 
         ArithmeticException inputException = new ArithmeticException();
-        Assertions.assertEquals(inputException, handler.handle(inputException));
+        assertEquals(inputException, handler.handle(inputException));
     }
 
     @Test
@@ -61,6 +64,6 @@ public class TolerantExceptionHandlerTests {
         TolerantExceptionHandler handler = new TolerantExceptionHandler(tolerantExceptions);
 
         ArithmeticException inputException = new ArithmeticException();
-        Assertions.assertEquals(inputException, handler.handle(inputException));
+        assertEquals(inputException, handler.handle(inputException));
     }
 }

--- a/src/test/java/uk/co/evoco/webdriver/utils/TolerantExceptionHandlerTests.java
+++ b/src/test/java/uk/co/evoco/webdriver/utils/TolerantExceptionHandlerTests.java
@@ -1,0 +1,66 @@
+package uk.co.evoco.webdriver.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.InvalidArgumentException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TolerantExceptionHandlerTests {
+
+    @Test
+    void testThrowsInputExceptionIfNoTolerantExceptionsAreListed() {
+        TolerantExceptionHandler handler = new TolerantExceptionHandler(new ArrayList<>());
+        NumberFormatException inputException = new NumberFormatException();
+        Assertions.assertThrows(NumberFormatException.class, () -> handler.handle(inputException));
+    }
+
+    @Test
+    void testThrowsInputExceptionIfNotOnListOfTolerantExceptions() {
+        List<String> tolerantExceptions = new ArrayList<>();
+        tolerantExceptions.add(NullPointerException.class.getName());
+        tolerantExceptions.add(InvalidArgumentException.class.getName());
+        tolerantExceptions.add(ArithmeticException.class.getName());
+        TolerantExceptionHandler handler = new TolerantExceptionHandler(tolerantExceptions);
+
+        NumberFormatException inputException = new NumberFormatException();
+        Assertions.assertThrows(NumberFormatException.class, () -> handler.handle(inputException));
+    }
+
+    @Test
+    void testReturnsInputExceptionIfOnListOfTolerantExceptions() throws Throwable {
+        List<String> tolerantExceptions = new ArrayList<>();
+        tolerantExceptions.add(NullPointerException.class.getName());
+        tolerantExceptions.add(ArithmeticException.class.getName());
+        tolerantExceptions.add(InvalidArgumentException.class.getName());
+        TolerantExceptionHandler handler = new TolerantExceptionHandler(tolerantExceptions);
+
+        ArithmeticException inputException = new ArithmeticException();
+        Assertions.assertEquals(inputException, handler.handle(inputException));
+    }
+
+    @Test
+    void testIgnoresInvalidValuesInTolerantExceptionList () throws Throwable {
+        List<String> tolerantExceptions = new ArrayList<>();
+        tolerantExceptions.add("NonExistentClass");
+        tolerantExceptions.add(InvalidArgumentException.class.getName());
+        tolerantExceptions.add(ArithmeticException.class.getName());
+        TolerantExceptionHandler handler = new TolerantExceptionHandler(tolerantExceptions);
+
+        ArithmeticException inputException = new ArithmeticException();
+        Assertions.assertEquals(inputException, handler.handle(inputException));
+    }
+
+    @Test
+    void testIgnoresClassesInTolerantExceptionListThatAreNotThrowable () throws Throwable {
+        List<String> tolerantExceptions = new ArrayList<>();
+        tolerantExceptions.add("java.lang.String");
+        tolerantExceptions.add(InvalidArgumentException.class.getName());
+        tolerantExceptions.add(ArithmeticException.class.getName());
+        TolerantExceptionHandler handler = new TolerantExceptionHandler(tolerantExceptions);
+
+        ArithmeticException inputException = new ArithmeticException();
+        Assertions.assertEquals(inputException, handler.handle(inputException));
+    }
+}

--- a/src/test/java/uk/co/evoco/webdriver/utils/TolerantExceptionHandlerTests.java
+++ b/src/test/java/uk/co/evoco/webdriver/utils/TolerantExceptionHandlerTests.java
@@ -16,7 +16,7 @@ public class TolerantExceptionHandlerTests {
     void testThrowsInputExceptionIfNoTolerantExceptionsAreListed() {
         TolerantExceptionHandler handler = new TolerantExceptionHandler(new ArrayList<>());
         NumberFormatException inputException = new NumberFormatException();
-        assertThrows(NumberFormatException.class, () -> handler.handle(inputException));
+        assertThrows(NumberFormatException.class, () -> handler.propagateIfNotIgnored(inputException));
     }
 
     @Test
@@ -28,7 +28,7 @@ public class TolerantExceptionHandlerTests {
         TolerantExceptionHandler handler = new TolerantExceptionHandler(tolerantExceptions);
 
         NumberFormatException inputException = new NumberFormatException();
-        assertThrows(NumberFormatException.class, () -> handler.handle(inputException));
+        assertThrows(NumberFormatException.class, () -> handler.propagateIfNotIgnored(inputException));
     }
 
     @Test
@@ -40,7 +40,7 @@ public class TolerantExceptionHandlerTests {
         TolerantExceptionHandler handler = new TolerantExceptionHandler(tolerantExceptions);
 
         ArithmeticException inputException = new ArithmeticException();
-        assertEquals(inputException, handler.handle(inputException));
+        assertEquals(inputException, handler.propagateIfNotIgnored(inputException));
     }
 
     @Test
@@ -52,7 +52,7 @@ public class TolerantExceptionHandlerTests {
         TolerantExceptionHandler handler = new TolerantExceptionHandler(tolerantExceptions);
 
         ArithmeticException inputException = new ArithmeticException();
-        assertEquals(inputException, handler.handle(inputException));
+        assertEquals(inputException, handler.propagateIfNotIgnored(inputException));
     }
 
     @Test
@@ -64,6 +64,6 @@ public class TolerantExceptionHandlerTests {
         TolerantExceptionHandler handler = new TolerantExceptionHandler(tolerantExceptions);
 
         ArithmeticException inputException = new ArithmeticException();
-        assertEquals(inputException, handler.handle(inputException));
+        assertEquals(inputException, handler.propagateIfNotIgnored(inputException));
     }
 }


### PR DESCRIPTION
## Fixes 
A slight bug in TolerantInteraction.propagateIfNotIgnored where all exceptions are ignored instead of only the ones on the list of ignored exceptions.

## Description
I moved the code out to a separate class and tested it. It's then used in the TolerantInteraction class. Other choice would be to make the method public on the TolerantInteraction class but that did not seem reasonable. 