### PR TITLE
Update WebDriverListener to extend AbstractWebDriverEventListener

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: java
 jdk:
-- openjdk12
+- openjdk13
 cache:
   directories:
   - "$HOME/.m2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_install:
 addons:
   firefox: latest
 install:
+- echo $JAVA_HOME
+- ls -la /usr/lib/jvm/
 - mvn clean install -Dmaven.javadoc.skip=true -B -V
 - bash scripts/get-bank-holiday-data-source-and-store-in-resources.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ before_install:
 addons:
   firefox: latest
 install:
-- echo $JAVA_HOME
-- ls -la /usr/lib/jvm/
 - mvn clean install -Dmaven.javadoc.skip=true -B -V
 - bash scripts/get-bank-holiday-data-source-and-store-in-resources.sh
 after_success:

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>12</maven.compiler.source>
-        <maven.compiler.target>12</maven.compiler.target>
+        <maven.compiler.source>13</maven.compiler.source>
+        <maven.compiler.target>13</maven.compiler.target>
         <maven.surefire.version>2.22.2</maven.surefire.version>
         <maven.failsafe.version>2.22.2</maven.failsafe.version>
         <junit.jupiter.version>5.5.2</junit.jupiter.version>

--- a/src/main/java/uk/co/evoco/webdriver/WebDriverListener.java
+++ b/src/main/java/uk/co/evoco/webdriver/WebDriverListener.java
@@ -6,7 +6,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.By;
-import org.openqa.selenium.support.events.WebDriverEventListener;
+import org.openqa.selenium.support.events.AbstractWebDriverEventListener;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
@@ -14,21 +14,21 @@ import org.slf4j.LoggerFactory;
 import uk.co.evoco.webdriver.configuration.TestConfigHelper;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 /**
  * This class allows us hooks into before and afters of a lot of WebDriver internals
  * This is a great way to capture screenshots and add conditional waits to actions without making
  * tests and page objects have superfluous code to do these things.
- *
- * We're implementing a core WebDriver interface in WebDriverEventListener here, so the declarations of methods
- * that have no contents is unfortunately necessary.  It just means in our world
- * that these "empty" methods do get called, but nothing happens, they just exit.
  */
-public class WebDriverListener implements WebDriverEventListener {
+public class WebDriverListener extends AbstractWebDriverEventListener {
 
     private static final Logger logger = LoggerFactory.getLogger(WebDriverListener.class);
     private File screenshotDirectory;
+    private Collection<Class<? extends Throwable>> exceptionsToIgnore = getExceptionsToIgnore();
 
     /**
      * Sets the screenshot target directory that will be used for screenshots generated inside onException()
@@ -36,104 +36,6 @@ public class WebDriverListener implements WebDriverEventListener {
      */
     public void setScreenshotDirectory(File screenshotDirectory) {
         this.screenshotDirectory = screenshotDirectory;
-    }
-
-    /**
-     *
-     * @param webDriver active WebDriver instance
-     */
-    public void beforeAlertAccept(WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webDriver active WebDriver instance
-     */
-    public void afterAlertAccept(WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webDriver active WebDriver instance
-     */
-    public void afterAlertDismiss(WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webDriver active WebDriver instance
-     */
-    public void beforeAlertDismiss(WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param s String
-     * @param webDriver active WebDriver instance
-     */
-    public void beforeNavigateTo(String s, WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param s String
-     * @param webDriver active WebDriver instance
-     */
-    public void afterNavigateTo(String s, WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webDriver active WebDriver instance
-     */
-    public void beforeNavigateBack(WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webDriver active WebDriver instance
-     */
-    public void afterNavigateBack(WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webDriver active WebDriver instance
-     */
-    public void beforeNavigateForward(WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webDriver active WebDriver instance
-     */
-    public void afterNavigateForward(WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webDriver active WebDriver instance
-     */
-    public void beforeNavigateRefresh(WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webDriver active WebDriver instance
-     */
-    public void afterNavigateRefresh(WebDriver webDriver) {
-        // nothing yet
     }
 
     /**
@@ -146,18 +48,9 @@ public class WebDriverListener implements WebDriverEventListener {
      */
     public void beforeFindBy(By by, WebElement webElement, WebDriver webDriver) {
         new WebDriverWait(webDriver,
-                TestConfigHelper.get().getWebDriverWaitTimeout()).until(
-                        ExpectedConditions.presenceOfElementLocated(by));
-    }
-
-    /**
-     *
-     * @param by locator
-     * @param webElement active WebElement, already located
-     * @param webDriver active WebDriver instance
-     */
-    public void afterFindBy(By by, WebElement webElement, WebDriver webDriver) {
-        // nothing yet
+                TestConfigHelper.get().getWebDriverWaitTimeout())
+                .ignoreAll(exceptionsToIgnore)
+                .until(ExpectedConditions.presenceOfElementLocated(by));
     }
 
     /**
@@ -171,73 +64,9 @@ public class WebDriverListener implements WebDriverEventListener {
      */
     public void beforeClickOn(WebElement webElement, WebDriver webDriver) {
         new WebDriverWait(webDriver,
-                TestConfigHelper.get().getWebDriverWaitTimeout()).until(
-                        ExpectedConditions.elementToBeClickable(webElement));
-    }
-
-    /**
-     *
-     * @param webElement active WebElement, already located
-     * @param webDriver active WebDriver instance
-     */
-    public void afterClickOn(WebElement webElement, WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webElement active WebElement, already located
-     * @param webDriver active WebDriver instance
-     * @param charSequences character sequence
-     */
-    public void beforeChangeValueOf(WebElement webElement, WebDriver webDriver, CharSequence[] charSequences) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webElement active WebElement, already located
-     * @param webDriver active WebDriver instance
-     * @param charSequences character sequence
-     */
-    public void afterChangeValueOf(WebElement webElement, WebDriver webDriver, CharSequence[] charSequences) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param s String
-     * @param webDriver active WebDriver instance
-     */
-    public void beforeScript(String s, WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param s String
-     * @param webDriver active WebDriver instance
-     */
-    public void afterScript(String s, WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param s String
-     * @param webDriver active WebDriver instance
-     */
-    public void beforeSwitchToWindow(String s, WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param s String
-     * @param webDriver active WebDriver instance
-     */
-    public void afterSwitchToWindow(String s, WebDriver webDriver) {
-        // nothing yet
+                TestConfigHelper.get().getWebDriverWaitTimeout())
+                .ignoreAll(exceptionsToIgnore)
+                .until(ExpectedConditions.elementToBeClickable(webElement));
     }
 
     /**
@@ -262,41 +91,14 @@ public class WebDriverListener implements WebDriverEventListener {
         }
     }
 
-    /**
-     *
-     * @param outputType output type
-     * @param <X> x
-     */
-    public <X> void beforeGetScreenshotAs(OutputType<X> outputType) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param outputType output type
-     * @param x x
-     * @param <X> x
-     */
-    public <X> void afterGetScreenshotAs(OutputType<X> outputType, X x) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webElement active WebElement, already located
-     * @param webDriver active WebDriver instance
-     */
-    public void beforeGetText(WebElement webElement, WebDriver webDriver) {
-        // nothing yet
-    }
-
-    /**
-     *
-     * @param webElement active WebElement, already located
-     * @param webDriver active WebDriver instance
-     * @param s String
-     */
-    public void afterGetText(WebElement webElement, WebDriver webDriver, String s) {
-        // nothing yet
+    private Collection<Class<? extends Throwable>> getExceptionsToIgnore() {
+        List<Class<? extends Throwable>> exceptionsToHandle = new ArrayList<>();
+        for(String exceptionName: TestConfigHelper.get().getTolerantActionExceptions().getExceptionsToHandle()) {
+            try {
+                exceptionsToHandle.add((Class<? extends Throwable>) Class.forName(exceptionName));
+            }
+            catch (ClassNotFoundException | ClassCastException ex) {}
+        }
+        return exceptionsToHandle;
     }
 }

--- a/src/main/java/uk/co/evoco/webdriver/WebDriverListener.java
+++ b/src/main/java/uk/co/evoco/webdriver/WebDriverListener.java
@@ -14,9 +14,6 @@ import org.slf4j.LoggerFactory;
 import uk.co.evoco.webdriver.configuration.TestConfigHelper;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -28,7 +25,6 @@ public class WebDriverListener extends AbstractWebDriverEventListener {
 
     private static final Logger logger = LoggerFactory.getLogger(WebDriverListener.class);
     private File screenshotDirectory;
-    private Collection<Class<? extends Throwable>> exceptionsToIgnore = getExceptionsToIgnore();
 
     /**
      * Sets the screenshot target directory that will be used for screenshots generated inside onException()
@@ -48,9 +44,8 @@ public class WebDriverListener extends AbstractWebDriverEventListener {
      */
     public void beforeFindBy(By by, WebElement webElement, WebDriver webDriver) {
         new WebDriverWait(webDriver,
-                TestConfigHelper.get().getWebDriverWaitTimeout())
-                .ignoreAll(exceptionsToIgnore)
-                .until(ExpectedConditions.presenceOfElementLocated(by));
+                TestConfigHelper.get().getWebDriverWaitTimeout()).until(
+                        ExpectedConditions.presenceOfElementLocated(by));
     }
 
     /**
@@ -64,9 +59,8 @@ public class WebDriverListener extends AbstractWebDriverEventListener {
      */
     public void beforeClickOn(WebElement webElement, WebDriver webDriver) {
         new WebDriverWait(webDriver,
-                TestConfigHelper.get().getWebDriverWaitTimeout())
-                .ignoreAll(exceptionsToIgnore)
-                .until(ExpectedConditions.elementToBeClickable(webElement));
+                TestConfigHelper.get().getWebDriverWaitTimeout()).until(
+                        ExpectedConditions.elementToBeClickable(webElement));
     }
 
     /**
@@ -89,16 +83,5 @@ public class WebDriverListener extends AbstractWebDriverEventListener {
         } catch (Exception e) {
             logger.error("Unable to Save to directory: {}", screenshotDirectory.getPath());
         }
-    }
-
-    private Collection<Class<? extends Throwable>> getExceptionsToIgnore() {
-        List<Class<? extends Throwable>> exceptionsToHandle = new ArrayList<>();
-        for(String exceptionName: TestConfigHelper.get().getTolerantActionExceptions().getExceptionsToHandle()) {
-            try {
-                exceptionsToHandle.add((Class<? extends Throwable>) Class.forName(exceptionName));
-            }
-            catch (ClassNotFoundException | ClassCastException ex) {}
-        }
-        return exceptionsToHandle;
     }
 }

--- a/src/test/resources/config.json
+++ b/src/test/resources/config.json
@@ -21,9 +21,9 @@
   "tolerantActionExceptions": {
     "waitTimeoutInSeconds": 5,
     "exceptionsToHandle": [
-      "StaleElementReferenceException",
-      "ElementClickInterceptedException",
-      "ElementNotInteractableException"
+      "org.openqa.selenium.ElementClickInterceptedException",
+      "org.openqa.selenium.ElementNotInteractableException",
+      "org.openqa.selenium.StaleElementReferenceException"
     ]
   },
   "metrics": {

--- a/src/test/resources/config.json
+++ b/src/test/resources/config.json
@@ -21,9 +21,9 @@
   "tolerantActionExceptions": {
     "waitTimeoutInSeconds": 5,
     "exceptionsToHandle": [
-      "org.openqa.selenium.ElementClickInterceptedException",
-      "org.openqa.selenium.ElementNotInteractableException",
-      "org.openqa.selenium.StaleElementReferenceException"
+      "StaleElementReferenceException",
+      "ElementClickInterceptedException",
+      "ElementNotInteractableException"
     ]
   },
   "metrics": {


### PR DESCRIPTION
## Fixes 
Removes unnecessary boilerplate code

## Description
We now have the AbstractWebDriverEventListener to extend from - this means we do not have to implement all the methods in the WebDriverEventListener interface.