### PR TITLE
Add performance logging through config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.12.1</jackson.version>
         <mockneat.version>0.4.2</mockneat.version>
+        <powermock.version>2.0.2</powermock.version>
         <dwp.formatvalidation.nino>1.3.0</dwp.formatvalidation.nino>
         <versions.maven.plugin.version>2.7</versions.maven.plugin.version>
         <jacoco.maven.plugin.version>0.8.5</jacoco.maven.plugin.version>
@@ -218,6 +219,18 @@
             <artifactId>selenium</artifactId>
             <version>4.1.2</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/uk/co/evoco/webdriver/configuration/WebDriverConfig.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/WebDriverConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.openqa.selenium.json.Json;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +26,7 @@ public class WebDriverConfig {
     private GridConfig gridConfig;
     private RunType runType;
     private Map<String, ObjectNode> browserPreferences;
+    private ObjectNode chromeLoggingPreferences;
     private TolerantActionExceptions tolerantActionExceptions;
     private MetricsConfig metricsConfig;
     private boolean takeScreenshotOnError;
@@ -164,11 +166,33 @@ public class WebDriverConfig {
 
     /**
      *
+     * @return the ChromeLoggingPreferences configuration
+     */
+    public Optional<String> getChromeLoggingPreferences() {
+        return Optional.ofNullable(chromeLoggingPreferences)
+                .map(configObject -> configObject.retain("logLevel"))
+                .filter(s -> !s.isEmpty())
+                .map(logLevelNode -> logLevelNode.get("logLevel").asText())
+                .stream()
+                .findFirst();
+    }
+
+    /**
+     *
      * @param browserPreferences the configuration properties for the various browsers supported by the webdriver
      */
     @JsonProperty("browserPreferences")
     public void setBrowserPreferences(Map<String, ObjectNode> browserPreferences) {
         this.browserPreferences = browserPreferences;
+    }
+
+    /**
+     *
+     * @param chromeLoggingPreferences the configuration logging level for the various browsers supported by the webdriver
+     */
+    @JsonProperty("chromeLoggingPreferences")
+    public void setChromeLoggingPreferences(ObjectNode chromeLoggingPreferences) {
+        this.chromeLoggingPreferences = chromeLoggingPreferences;
     }
 
     /**

--- a/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredChromeDriver.java
+++ b/src/main/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredChromeDriver.java
@@ -5,17 +5,26 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.logging.LoggingPreferences;
+import org.openqa.selenium.remote.CapabilityType;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.co.evoco.tests.BaseAbstractTest;
 import uk.co.evoco.webdriver.configuration.BrowserType;
 import uk.co.evoco.webdriver.configuration.TestConfigHelper;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.logging.Level;
 
 public class ConfiguredChromeDriver implements ConfiguredDriver {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConfiguredChromeDriver.class);
 
     /**
      *
@@ -23,8 +32,13 @@ public class ConfiguredChromeDriver implements ConfiguredDriver {
      * @return WebDriver representing RemoteWebDriver grid
      */
     public WebDriver getRemoteDriver() throws IOException {
+        ChromeOptions chromeOptions = this.getOptions();
+        LoggingPreferences loggingOptions = this.getLoggerPrefs();
+        DesiredCapabilities capabilities = DesiredCapabilities.chrome();
+        capabilities.setCapability("goog:loggingPrefs", loggingOptions);
+        chromeOptions.merge(capabilities);
         return new RemoteWebDriver(
-                TestConfigHelper.get().getGridConfig().getGridUrl(), this.getOptions());
+                TestConfigHelper.get().getGridConfig().getGridUrl(), chromeOptions);
     }
 
     /**
@@ -33,10 +47,16 @@ public class ConfiguredChromeDriver implements ConfiguredDriver {
      * @throws IOException if log directory doesn't exist
      */
     public WebDriver getLocalDriver() throws IOException {
+        ChromeOptions chromeOptions = this.getOptions();
+        LoggingPreferences loggingOptions = this.getLoggerPrefs();
+        DesiredCapabilities capabilities = DesiredCapabilities.chrome();
+        capabilities.setCapability("goog:loggingPrefs", loggingOptions);
+        chromeOptions.merge(capabilities);
+
         createLogDirectory();
         System.setProperty("webdriver.chrome.logfile", "logs/chrome-driver.log");
         WebDriverManager.chromedriver().setup();
-        return new ChromeDriver(this.getOptions());
+        return new ChromeDriver(chromeOptions);
     }
 
     /**
@@ -68,8 +88,42 @@ public class ConfiguredChromeDriver implements ConfiguredDriver {
                     }
             }
         }
+
+        if(!getLoggerPrefs().getLevel(LogType.PERFORMANCE).getName().equals("OFF")) {
+            Map<String, Object> perfLogPrefs = new HashMap<>();
+            perfLogPrefs.put("traceCategories", "browser,devtools.timeline,devtools");
+            chromeOptions.setExperimentalOption("perfLoggingPrefs", perfLogPrefs);
+        }
+
         chromeOptions.setExperimentalOption("prefs", chromePrefs);
         chromeOptions.setHeadless(TestConfigHelper.get().isHeadless());
         return chromeOptions;
+    }
+
+    public LoggingPreferences getLoggerPrefs() {
+        LoggingPreferences loggingPreferences = new LoggingPreferences();
+        TestConfigHelper.get()
+                .getChromeLoggingPreferences()
+                .ifPresent(logLevel -> {
+                    try {
+                        System.setProperty("webdriver.chrome.verboseLogging", "true");
+                        loggingPreferences.enable(LogType.PERFORMANCE, parseLogLevel(logLevel));
+                        loggingPreferences.enable(LogType.BROWSER, parseLogLevel(logLevel));
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                });
+
+        return loggingPreferences;
+    }
+
+    private Level parseLogLevel(String logLevel) {
+        try {
+            return Level.parse(logLevel);
+        }
+        catch (IllegalArgumentException exception) {
+            logger.warn("Incorrect Level provided so performance logging set to OFF");
+            return Level.OFF;
+        }
     }
 }

--- a/src/test/java/uk/co/evoco/webdriver/configuration/WebDriverConfigTests.java
+++ b/src/test/java/uk/co/evoco/webdriver/configuration/WebDriverConfigTests.java
@@ -10,6 +10,7 @@ import uk.co.evoco.webdriver.utils.JsonUtils;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -51,7 +52,7 @@ public class WebDriverConfigTests {
     public void testGetBrowserPreferencesReturnsTheCorrectBrowserOptions() throws JsonProcessingException {
         String preferenceKey = "browser.download.dir";
         String preferenceValue = "docs/chrome/";
-        String inputConfigJson = String.format("{ \"browserPreferences\": { \"chrome\": {\"%s\": \"%s\"}}}", preferenceKey, preferenceValue);
+        String inputConfigJson = String.format("{ \"browserPreferences\": { \"chrome\": {\"%s\": \"%s\"} }}", preferenceKey, preferenceValue);
 
         WebDriverConfig webDriverConfig = JsonUtils.fromString(inputConfigJson, WebDriverConfig.class);
         JsonNode actualPreferences = webDriverConfig.getBrowserPreferences(BrowserType.CHROME);
@@ -73,6 +74,50 @@ public class WebDriverConfigTests {
         ObjectNode expectedPreferences = JsonNodeFactory.instance.objectNode()
                 .put(preferenceKey, preferenceValue);
         assertThat(actualPreferences, is(expectedPreferences));
+    }
+
+    @Test
+    public void testGetLoggingPreferencesGetsTheRightOptions() throws IOException {
+        WebDriverConfig webDriverConfig = JsonUtils.fromFile(
+                ClassLoader.getSystemResourceAsStream("fixtures/sample-config-with-chrome-logging-preferences.json"),
+                WebDriverConfig.class);
+
+        assertThat(webDriverConfig.getChromeLoggingPreferences(), is(Optional.of("ALL")));
+    }
+
+    @Test
+    public void testWrongLogKeyReturnsEmptyOptional() throws IOException {
+        String logKey = "wrongLogKey";
+        String logValue = "ALL";
+        String inputConfigJson = String.format("{ \"chromeLoggingPreferences\": {\"%s\": \"%s\"}}}", logKey, logValue);
+
+        WebDriverConfig webDriverConfig = JsonUtils.fromString(inputConfigJson, WebDriverConfig.class);
+
+        Optional<String> actualPreferences = webDriverConfig.getChromeLoggingPreferences();
+        assertThat(actualPreferences, is(Optional.empty()));
+    }
+
+    @Test
+    public void testBlankLogLevelAndValueReturnsEmptyOptional() throws IOException {
+        String logKey = "";
+        String logValue = "";
+        String inputConfigJson = String.format("{ \"chromeLoggingPreferences\": {\"%s\": \"%s\"}}}", logKey, logValue);
+
+        WebDriverConfig webDriverConfig = JsonUtils.fromString(inputConfigJson, WebDriverConfig.class);
+
+        Optional<String> actualPreferences = webDriverConfig.getChromeLoggingPreferences();
+        assertThat(actualPreferences, is(Optional.empty()));
+    }
+
+    @Test
+    public void testMultipleLogLevelsReturnsFirstElement() throws IOException {
+
+        String inputConfigJson = "{ \"chromeLoggingPreferences\": {\"logLevel\": \"All\", \"logLevel\": \"FINE\"}}}";
+
+        WebDriverConfig webDriverConfig = JsonUtils.fromString(inputConfigJson, WebDriverConfig.class);
+
+        Optional<String> actualPreferences = webDriverConfig.getChromeLoggingPreferences();
+        assertThat(actualPreferences, is(Optional.of("FINE")));
     }
 
     @Test

--- a/src/test/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredChromeDriverTests.java
+++ b/src/test/java/uk/co/evoco/webdriver/configuration/driver/ConfiguredChromeDriverTests.java
@@ -2,29 +2,48 @@ package uk.co.evoco.webdriver.configuration.driver;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.LoggingPreferences;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.powermock.api.mockito.PowerMockito;
+import uk.co.evoco.webdriver.configuration.TestConfigHelper;
+import uk.co.evoco.webdriver.configuration.WebDriverConfig;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Level;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ConfiguredChromeDriverTests {
 
+    @Mock
+    WebDriverConfig webDriverConfigMock = mock(WebDriverConfig.class);
+
     @Test
-    public void testReturnsLocalWebDriver() throws IOException {
+    public void testReturnsLocalWebDriver() throws IOException, IllegalAccessException {
+        Field testConfigHelperStaticVariable = PowerMockito.field(TestConfigHelper.class, "testConfigHelper");
+        testConfigHelperStaticVariable.set(TestConfigHelper.class, null);
+
         ConfiguredDriver configuredChromeDriver = new ConfiguredChromeDriver();
         WebDriver webDriver = configuredChromeDriver.getDriver(FileUtils.getTempDirectory());
         assertThat(webDriver, instanceOf(EventFiringWebDriver.class));
     }
 
     @Test
-    public void testGetOptionsReturnsOptionsIncludedInChromeConfig() throws IOException {
+    public void testGetOptionsReturnsOptionsIncludedInChromeConfig() throws IOException, IllegalAccessException {
+        Field testConfigHelperStaticVariable = PowerMockito.field(TestConfigHelper.class, "testConfigHelper");
+        testConfigHelperStaticVariable.set(TestConfigHelper.class, null);
+
         ConfiguredChromeDriver configuredChromeDriver = new ConfiguredChromeDriver();
         Map<String, Object> chromeOptions = getOptions(configuredChromeDriver.getOptions());
         String expectedFileDownLoadPath = new File("run-generated-files/chrome/downloads").getCanonicalPath();
@@ -33,8 +52,45 @@ public class ConfiguredChromeDriverTests {
         assertThat(chromeOptions.get("safebrowsing.enabled"), is(true));
     }
 
+    @Test
+    public void testGetLoggingPreferencesReturnsEnabledLogLevel() throws Exception {
+
+        Optional<String> mockConfigReturn = Optional.of("FINE");
+        mockTestConfig();
+        when(webDriverConfigMock.getChromeLoggingPreferences()).thenReturn(mockConfigReturn);
+
+
+        ConfiguredChromeDriver configuredChromeDriver = new ConfiguredChromeDriver();
+        LoggingPreferences loggingPreferences = configuredChromeDriver.getLoggerPrefs();
+
+        Level googleChromeLoggingPreferences = loggingPreferences.getLevel("performance");
+
+        assertThat(googleChromeLoggingPreferences, is(Level.FINE));
+    }
+
+    @Test
+    public void testEmptyLoggingPreferencesReturnsOffLevel() throws IllegalAccessException {
+        Optional<String> mockConfigReturn = Optional.of("");
+        mockTestConfig();
+        when(webDriverConfigMock.getChromeLoggingPreferences()).thenReturn(mockConfigReturn);
+
+        ConfiguredChromeDriver configuredChromeDriver = new ConfiguredChromeDriver();
+        LoggingPreferences loggingPreferences = configuredChromeDriver.getLoggerPrefs();
+
+        Level googleChromeLoggingPreferences = loggingPreferences.getLevel("performance");
+
+        assertThat(googleChromeLoggingPreferences, is(Level.OFF));
+    }
+
     private Map<String, Object> getOptions(ChromeOptions options) {
         Map<String, Object> googleChromeOptions = (Map<String, Object>) options.asMap().get("goog:chromeOptions");
         return (Map<String, Object>) googleChromeOptions.get("prefs");
+    }
+
+    private void mockTestConfig() throws IllegalAccessException {
+        Field testConfigHelperStaticVariable = PowerMockito.field(TestConfigHelper.class, "testConfigHelper");
+        testConfigHelperStaticVariable.set(TestConfigHelper.class, mock(TestConfigHelper.class));
+        Field webdriverConfigStaticVariable = PowerMockito.field(TestConfigHelper.class, "webDriverConfig");
+        webdriverConfigStaticVariable.set(TestConfigHelper.class, webDriverConfigMock);
     }
 }

--- a/src/test/java/uk/co/evoco/webdriver/utils/ChromeDriverPreferenceTests.java
+++ b/src/test/java/uk/co/evoco/webdriver/utils/ChromeDriverPreferenceTests.java
@@ -3,10 +3,15 @@ package uk.co.evoco.webdriver.utils;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.*;
 import org.openqa.selenium.By;
+import org.openqa.selenium.InvalidArgumentException;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.logging.LogType;
+import org.powermock.api.mockito.PowerMockito;
+import uk.co.evoco.webdriver.configuration.TestConfigHelper;
 import uk.co.evoco.webdriver.configuration.driver.ConfiguredChromeDriver;
 
 import java.io.File;
+import java.lang.reflect.Field;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -17,8 +22,8 @@ public class ChromeDriverPreferenceTests {
     private static EmbeddedJetty embeddedJetty;
     private WebDriver webDriver;
 
-    @BeforeAll
-    public static void webDriverSetup() throws Exception {
+    @BeforeEach
+    public void webDriverSetup() throws Exception {
         embeddedJetty = new EmbeddedJetty();
         embeddedJetty.start();
         baseUrl = "http://localhost:" + embeddedJetty.getPort() + "/index.html";
@@ -36,13 +41,27 @@ public class ChromeDriverPreferenceTests {
                 new File(expectedFile).exists(), is(true));
     }
 
-    @AfterEach
-    public void tearDown() {
-        this.webDriver.quit();
+    @Test
+    public void testChromeBrowserLoggingPreferencesApplied() throws Exception {
+        Field testConfigHelperStaticVariable = PowerMockito.field(TestConfigHelper.class, "testConfigHelper");
+        testConfigHelperStaticVariable.set(TestConfigHelper.class, null);
+
+        System.setProperty("config", "fixtures/sample-config-with-chrome-logging-preferences.json");
+        assertThat(System.getProperty("config"), is("fixtures/sample-config-with-chrome-logging-preferences.json"));
+        webDriver = new ConfiguredChromeDriver().getDriver(FileUtils.getTempDirectory());
+        webDriver.get(baseUrl);
+        webDriver.findElement(By.xpath("//a[text()='clickHereToDownLoadAFile']"));
+        try {
+            Assertions.assertTrue(webDriver.manage().logs().get(LogType.PERFORMANCE).getAll().size() > 0);
+        } catch (InvalidArgumentException e) {
+            Assertions.fail("There are no Performance Logs that have been found");
+        }
     }
 
-    @AfterAll
-    public static void webDriverTearDown() throws Exception {
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        this.webDriver.quit();
         System.setProperty("config", "DEFAULT");
         embeddedJetty.stop();
     }

--- a/src/test/resources/fixtures/sample-config-with-chrome-logging-preferences.json
+++ b/src/test/resources/fixtures/sample-config-with-chrome-logging-preferences.json
@@ -1,0 +1,42 @@
+{
+  "browser": "chrome",
+  "baseUrl": "https://www.google.com",
+  "timeout": "30",
+  "headless": true,
+  "runType": "LOCAL",
+  "takeScreenshotOnError": true,
+  "testConfig": {
+    "sample": "sample text"
+  },
+  "gridConfig": {
+    "url": "http://localhost:4444/wd/hub"
+  },
+  "browserPreferences": {
+    "chrome": {
+      "profile.default_content_settings.popups": 0,
+      "download.default_directory": "run-generated-files/chrome/downloads",
+      "safebrowsing.enabled": true
+    }
+  },
+  "chromeLoggingPreferences": {
+    "logLevel": "ALL"
+  },
+  "tolerantActionExceptions": {
+    "waitTimeoutInSeconds": 5,
+    "exceptionsToHandle": [
+      "StaleElementReferenceException",
+      "ElementClickInterceptedException",
+      "ElementNotInteractableException"
+    ]
+  },
+  "metrics": {
+    "jmx": {
+      "enabled": false
+    },
+    "graphite": {
+      "enabled": false,
+      "host": "localhost",
+      "port": 2003
+    }
+  }
+}


### PR DESCRIPTION
*When user provides chrome logging options in the config the system will set the performance logs to the level specified in the config. It will also turn on verbose logging and Browser logs to the same level.
* Added Power mock to mock out static members for the unit tests

## Fixes 
Tag GitHub issue tickets here

## Description
The goal of this is to allow the user to set more verbose chromedriver logs so they can investigate issues with their services.
