### PR TITLE
Selenium 3.141.59 to 4.0.0 Upgrade 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,4 @@ src/main/resources/bank-holidays.json
 node_modules
 dist
 run-generated-files/*
-.vscode/*
+**/.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,4 @@ src/main/resources/bank-holidays.json
 node_modules
 dist
 run-generated-files/*
-.vscode
+.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ src/main/resources/bank-holidays.json
 node_modules
 dist
 run-generated-files/*
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <maven.failsafe.version>2.22.2</maven.failsafe.version>
         <junit.jupiter.version>5.5.2</junit.jupiter.version>
         <jetty.version>9.4.41.v20210516</jetty.version>
-        <selenium.version>3.141.59</selenium.version>
+        <selenium.version>4.0.0</selenium.version>
         <webdriver.manager.version>4.4.3</webdriver.manager.version>
         <slf4j.version>1.6.4</slf4j.version>
         <logback.version>1.2.3</logback.version>


### PR DESCRIPTION
This pull request is to upgrade the Selenium Java Framework from 3.141.59 to 4.0.0. The upgrade was done by upgrading the dependancies in the pom.xml where the build tool used in the Selenium Java Framework was Maven.

After the upgrade, there were no breaking changes and most of the tests ran were successfully in Selenium 4.

The following resources were used to check the code base to see if it was not using any of the deprecated methods:
https://applitools.medium.com/migrating-to-selenium-4-heres-what-has-changed-5a9f7e08971c
https://www.selenium.dev/selenium/docs/api/java/deprecated-list.html
https://saucelabs.com/resources/articles/how-to-upgrade-to-selenium-4
https://www.selenium.dev/documentation/webdriver/getting_started/upgrade_to_selenium_4/